### PR TITLE
Fix six timer and settings bugs

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -18,9 +18,6 @@
     <string name="screen_title">Bildschirm</string>
     <string name="screen_description">Bildschirm sperren wenn Timer endet</string>
     <string name="screen_admin_required">Geräteadministrator-Berechtigung erforderlich</string>
-    <string name="category_notification">Benachrichtigung</string>
-    <string name="notification_title">Benachrichtigung aktivieren</string>
-    <string name="notification_description">Verbleibende Zeit und Schnellzugriff anzeigen</string>
     <string name="category_haptic">Haptisches Feedback</string>
     <string name="haptic_title">Haptisches Feedback</string>
     <string name="haptic_description">Vibrieren bei Verwendung von Timer und Bedienelementen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,9 +18,6 @@
     <string name="screen_title">Screen</string>
     <string name="screen_description">Lock screen when timer ends</string>
     <string name="screen_admin_required">Device admin permission required</string>
-    <string name="category_notification">Notification</string>
-    <string name="notification_title">Enable notification</string>
-    <string name="notification_description">Show remaining time and quick actions</string>
     <string name="category_haptic">Haptic Feedback</string>
     <string name="haptic_title">Haptic feedback</string>
     <string name="haptic_description">Vibrate when using timer and controls</string>

--- a/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/model/UserSettings.kt
+++ b/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/model/UserSettings.kt
@@ -4,7 +4,6 @@ data class UserSettings(
     val stopMediaPlayback: Boolean = true,
     val fadeOutDurationSeconds: Int = 30,
     val screenOff: Boolean = false,
-    val notificationEnabled: Boolean = true,
     val hapticFeedbackEnabled: Boolean = true,
     val theme: ThemeId = ThemeId.Default,
     val starsEnabled: Boolean = true,

--- a/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/repository/SettingsRepository.kt
+++ b/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/repository/SettingsRepository.kt
@@ -9,7 +9,6 @@ interface SettingsRepository {
     suspend fun updateStopMediaPlayback(enabled: Boolean)
     suspend fun updateFadeOutDuration(seconds: Int)
     suspend fun updateScreenOff(enabled: Boolean)
-    suspend fun updateNotificationEnabled(enabled: Boolean)
     suspend fun updateHapticFeedback(enabled: Boolean)
     suspend fun updateTheme(theme: ThemeId)
     suspend fun updateStarsEnabled(enabled: Boolean)

--- a/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/repository/SettingsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/repository/SettingsRepositoryImpl.kt
@@ -22,7 +22,6 @@ class SettingsRepositoryImpl @Inject constructor(
         val STOP_MEDIA = booleanPreferencesKey("stop_media_playback")
         val FADE_OUT_DURATION = intPreferencesKey("fade_out_duration_seconds")
         val SCREEN_OFF = booleanPreferencesKey("screen_off")
-        val NOTIFICATION_ENABLED = booleanPreferencesKey("notification_enabled")
         val HAPTIC_FEEDBACK = booleanPreferencesKey("haptic_feedback")
         val THEME = stringPreferencesKey("theme")
         val STARS_ENABLED = booleanPreferencesKey("stars_enabled")
@@ -33,7 +32,6 @@ class SettingsRepositoryImpl @Inject constructor(
             stopMediaPlayback = prefs[STOP_MEDIA] ?: true,
             fadeOutDurationSeconds = prefs[FADE_OUT_DURATION] ?: 30,
             screenOff = prefs[SCREEN_OFF] ?: false,
-            notificationEnabled = prefs[NOTIFICATION_ENABLED] ?: true,
             hapticFeedbackEnabled = prefs[HAPTIC_FEEDBACK] ?: true,
             theme = ThemeId.fromStorage(prefs[THEME]),
             starsEnabled = prefs[STARS_ENABLED] ?: true,
@@ -50,10 +48,6 @@ class SettingsRepositoryImpl @Inject constructor(
 
     override suspend fun updateScreenOff(enabled: Boolean) {
         dataStore.edit { it[SCREEN_OFF] = enabled }
-    }
-
-    override suspend fun updateNotificationEnabled(enabled: Boolean) {
-        dataStore.edit { it[NOTIFICATION_ENABLED] = enabled }
     }
 
     override suspend fun updateHapticFeedback(enabled: Boolean) {

--- a/core/service/src/main/kotlin/dev/mato/sleeptimer/core/service/SleepTimerService.kt
+++ b/core/service/src/main/kotlin/dev/mato/sleeptimer/core/service/SleepTimerService.kt
@@ -105,7 +105,6 @@ class SleepTimerService : Service() {
 
                 updateTimerState(TimerPhase.RUNNING)
 
-                // Update notification every 10 seconds or when minutes change
                 val remainingMinutes = (remainingMillis / 60_000).toInt()
                 notificationManager.updateNotification(remainingMinutes)
             }

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/settings/SettingsScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/settings/SettingsScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.MusicOff
-import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material3.Icon
@@ -55,10 +54,11 @@ fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val ready = uiState ?: return
 
-    CompositionLocalProvider(LocalAppTheme provides AppThemes.byId(uiState.settings.theme)) {
+    CompositionLocalProvider(LocalAppTheme provides AppThemes.byId(ready.settings.theme)) {
         SettingsContent(
-            uiState = uiState,
+            uiState = ready,
             onBack = onBack,
             viewModel = viewModel,
         )
@@ -156,15 +156,6 @@ private fun SettingsContent(
                             viewModel.updateScreenOff(enabled)
                         }
                     },
-                )
-
-                SectionHeader(stringResource(R.string.category_notification))
-                SettingsToggleRow(
-                    icon = Icons.Default.Notifications,
-                    title = stringResource(R.string.notification_title),
-                    description = stringResource(R.string.notification_description),
-                    checked = uiState.settings.notificationEnabled,
-                    onCheckedChange = { viewModel.updateNotificationEnabled(it) },
                 )
 
                 SectionHeader(stringResource(R.string.category_haptic))

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/settings/SettingsViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/settings/SettingsViewModel.kt
@@ -29,14 +29,14 @@ class SettingsViewModel @Inject constructor(
         "dev.mato.sleeptimer.receiver.SleepTimerDeviceAdminReceiver",
     )
 
-    val uiState: StateFlow<SettingsUiState> = settingsRepository.settings
+    val uiState: StateFlow<SettingsUiState?> = settingsRepository.settings
         .map { settings ->
             SettingsUiState(
                 settings = settings,
                 isDeviceAdminEnabled = devicePolicyManager.isAdminActive(adminComponent),
             )
         }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), SettingsUiState())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     fun isDeviceAdminActive(): Boolean {
         return devicePolicyManager.isAdminActive(adminComponent)
@@ -54,10 +54,6 @@ class SettingsViewModel @Inject constructor(
 
     fun updateScreenOff(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.updateScreenOff(enabled) }
-    }
-
-    fun updateNotificationEnabled(enabled: Boolean) {
-        viewModelScope.launch { settingsRepository.updateNotificationEnabled(enabled) }
     }
 
     fun updateHapticFeedback(enabled: Boolean) {

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -128,18 +128,11 @@ private fun TimerContent(
                 )
 
                 when (val s = uiState) {
-                    is TimerUiState.Idle -> TimeDisplay(
-                        totalMinutes = s.selectedMinutes,
-                        label = "",
-                    )
+                    is TimerUiState.Idle -> TimeDisplay(totalMinutes = s.selectedMinutes)
                     is TimerUiState.Running -> TimeDisplay(
-                        totalMinutes = s.remainingMinutes.coerceAtLeast(if (s.remainingSeconds > 0) 1 else 0),
-                        label = "remaining",
+                        totalMinutes = s.remainingMinutes + if (s.remainingSeconds > 0) 1 else 0,
                     )
-                    is TimerUiState.FadingOut -> TimeDisplay(
-                        totalMinutes = 0,
-                        label = "fading out",
-                    )
+                    is TimerUiState.FadingOut -> TimeDisplay(totalMinutes = 0)
                 }
             }
 

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/components/CircularDial.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/components/CircularDial.kt
@@ -1,5 +1,7 @@
 package dev.mato.sleeptimer.feature.timer.timer.components
 
+import android.os.Build
+import android.view.HapticFeedbackConstants
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
@@ -20,7 +22,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import dev.mato.sleeptimer.feature.timer.theme.AppTheme
 import dev.mato.sleeptimer.feature.timer.theme.appTheme
@@ -37,7 +39,14 @@ fun CircularDial(
     modifier: Modifier = Modifier,
 ) {
     val theme = appTheme()
-    val hapticFeedback = LocalHapticFeedback.current
+    val view = LocalView.current
+    val tickHapticType = remember {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            HapticFeedbackConstants.SEGMENT_TICK
+        } else {
+            HapticFeedbackConstants.CLOCK_TICK
+        }
+    }
     var lastReportedMinutes by remember { mutableStateOf(state.totalMinutes) }
 
     val displayMinutes: Float = if (isRunning) runningMinutes else state.totalMinutes.toFloat()
@@ -74,9 +83,7 @@ fun CircularDial(
                                     )
                                     if (state.totalMinutes != lastReportedMinutes) {
                                         if (hapticEnabled) {
-                                            hapticFeedback.performHapticFeedback(
-                                                androidx.compose.ui.hapticfeedback.HapticFeedbackType.TextHandleMove,
-                                            )
+                                            view.performHapticFeedback(tickHapticType)
                                         }
                                         lastReportedMinutes = state.totalMinutes
                                         onMinutesChanged(state.totalMinutes)

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/components/CircularDialState.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/components/CircularDialState.kt
@@ -19,50 +19,53 @@ class CircularDialState {
 
     private var previousAngle = 90f
     private var isDragging = false
+    private var cumulativeDegrees = 0f
 
     val maxRevolutions = 5 // 5 hours
     private val maxMinutes = maxRevolutions * 60
+    private val maxDegrees = maxRevolutions * 360f
+
+    init {
+        // Sync cumulative with default totalMinutes (15)
+        cumulativeDegrees = (totalMinutes / 60f) * 360f
+        revolutions = totalMinutes / 60
+        angleDegrees = cumulativeDegrees - revolutions * 360f
+    }
 
     fun onDragStart(centerX: Float, centerY: Float, x: Float, y: Float) {
         isDragging = true
         previousAngle = computeAngle(centerX, centerY, x, y)
+        cumulativeDegrees = (revolutions * 360f + angleDegrees).coerceIn(0f, maxDegrees)
     }
 
     fun onDrag(centerX: Float, centerY: Float, x: Float, y: Float) {
         if (!isDragging) return
 
         val newAngle = computeAngle(centerX, centerY, x, y)
-        val rawDelta = newAngle - previousAngle
+        var delta = newAngle - previousAngle
+        if (delta > 180f) delta -= 360f
+        else if (delta < -180f) delta += 360f
 
-        if (rawDelta > 180f) {
-            if (revolutions > 0) revolutions--
-        } else if (rawDelta < -180f) {
-            if (revolutions < maxRevolutions) revolutions++
-        }
-
-        angleDegrees = newAngle
+        cumulativeDegrees = (cumulativeDegrees + delta).coerceIn(0f, maxDegrees)
         previousAngle = newAngle
-        recalculateMinutes()
+
+        revolutions = (cumulativeDegrees / 360f).toInt().coerceAtMost(maxRevolutions)
+        angleDegrees = cumulativeDegrees - revolutions * 360f
+        totalMinutes = ((cumulativeDegrees / 360f) * 60f).roundToInt().coerceIn(0, maxMinutes)
     }
 
     fun onDragEnd() {
         isDragging = false
-        val minuteInRevolution = ((angleDegrees / 360f) * 60f).roundToInt().coerceIn(0, 59)
-        angleDegrees = (minuteInRevolution / 60f) * 360f
-        recalculateMinutes()
+        setMinutes(totalMinutes)
     }
 
     fun setMinutes(minutes: Int) {
         val clamped = minutes.coerceIn(0, maxMinutes)
+        totalMinutes = clamped
+        cumulativeDegrees = (clamped / 60f) * 360f
         revolutions = clamped / 60
         val remainder = clamped % 60
         angleDegrees = (remainder / 60f) * 360f
-        totalMinutes = clamped
-    }
-
-    private fun recalculateMinutes() {
-        val minuteInRevolution = ((angleDegrees / 360f) * 60f).roundToInt().coerceIn(0, 59)
-        totalMinutes = (revolutions * 60 + minuteInRevolution).coerceIn(0, maxMinutes)
     }
 
     private fun computeAngle(centerX: Float, centerY: Float, x: Float, y: Float): Float {

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/components/TimeDisplay.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/components/TimeDisplay.kt
@@ -14,7 +14,6 @@ import dev.mato.sleeptimer.feature.timer.theme.appTheme
 @Composable
 fun TimeDisplay(
     totalMinutes: Int,
-    label: String,
     modifier: Modifier = Modifier,
 ) {
     val theme = appTheme()
@@ -49,7 +48,7 @@ fun TimeDisplay(
         )
         Spacer(modifier = Modifier.height(6.dp))
         Text(
-            text = label.ifEmpty { small }.uppercase(),
+            text = small.uppercase(),
             style = MaterialTheme.typography.labelLarge,
             color = theme.textDim,
         )

--- a/feature/timer/src/main/res/values-de/strings.xml
+++ b/feature/timer/src/main/res/values-de/strings.xml
@@ -20,9 +20,6 @@
     <string name="screen_title">Bildschirm</string>
     <string name="screen_description">Bildschirm sperren wenn Timer endet</string>
     <string name="screen_admin_required">Geräteadministrator-Berechtigung erforderlich</string>
-    <string name="category_notification">Benachrichtigung</string>
-    <string name="notification_title">Benachrichtigung aktivieren</string>
-    <string name="notification_description">Verbleibende Zeit und Schnellzugriff anzeigen</string>
     <string name="category_haptic">Haptisches Feedback</string>
     <string name="haptic_title">Haptisches Feedback</string>
     <string name="haptic_description">Vibrieren bei Verwendung von Timer und Bedienelementen</string>

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -20,9 +20,6 @@
     <string name="screen_title">Screen</string>
     <string name="screen_description">Lock screen when timer ends</string>
     <string name="screen_admin_required">Device admin permission required</string>
-    <string name="category_notification">Notification</string>
-    <string name="notification_title">Enable notification</string>
-    <string name="notification_description">Show remaining time and quick actions</string>
     <string name="category_haptic">Haptic Feedback</string>
     <string name="haptic_title">Haptic feedback</string>
     <string name="haptic_description">Vibrate when using timer and controls</string>


### PR DESCRIPTION
## Summary
- **Running label**: `TimeDisplay` always derives `minute(s)`/`hour(s)` from the value; the REMAINING/FADING OUT override is gone.
- **Minute jump**: running display now ceils the remainder, so 30 min stays 30 until a full minute elapses.
- **Dial wrap**: `CircularDialState` tracks a cumulative rotation clamped to `[0, 5·360]°`, so dragging past 0 (or 300) no longer wraps.
- **Settings toggle flash**: `SettingsViewModel` starts with `null` and the screen returns early until the first repository emission, so toggles never render with the default-true state.
- **Haptic feedback**: dial ticks call `View.performHapticFeedback` with `SEGMENT_TICK` (API 34+) / `CLOCK_TICK` (older), which is perceptible where Compose's `TextHandleMove` was silent.
- **Notification toggle**: the in-app "enable notification" setting is removed. The existing low-importance "Sleep Timer" channel is still disableable from the system notification settings.

## Test plan
- [ ] Start a 30 min timer → display stays at `30 MINUTES` for the first minute, counts down cleanly to `1 MINUTE` and then `0`.
- [ ] Start a 1 min timer → display behaviour unchanged.
- [ ] Drag the dial counter-clockwise past 0 → stays at 0, does not wrap to 59.
- [ ] Drag the dial clockwise past max → stays at 300 (5h).
- [ ] Open Settings → toggles render directly in their stored state, no momentary "all on" flash.
- [ ] Enable haptics, scrub the dial → feel a tick at each minute boundary.
- [ ] Verify the "Sleep Timer" notification channel can be disabled from the system's app-notification settings, and that doing so hides the timer notification.