### PR TITLE
Keep minus button active while timer runs

### DIFF
--- a/core/service/src/main/kotlin/dev/mato/sleeptimer/core/service/SleepTimerService.kt
+++ b/core/service/src/main/kotlin/dev/mato/sleeptimer/core/service/SleepTimerService.kt
@@ -43,6 +43,7 @@ class SleepTimerService : Service() {
         const val ACTION_START = "dev.mato.sleeptimer.action.START"
         const val ACTION_CANCEL = "dev.mato.sleeptimer.action.CANCEL"
         const val ACTION_ADD_FIVE = "dev.mato.sleeptimer.action.ADD_FIVE"
+        const val ACTION_SUBTRACT_FIVE = "dev.mato.sleeptimer.action.SUBTRACT_FIVE"
         const val EXTRA_DURATION_MILLIS = "dev.mato.sleeptimer.extra.DURATION_MILLIS"
     }
 
@@ -58,6 +59,9 @@ class SleepTimerService : Service() {
             }
             ACTION_ADD_FIVE -> {
                 addFiveMinutes()
+            }
+            ACTION_SUBTRACT_FIVE -> {
+                subtractFiveMinutes()
             }
             ACTION_CANCEL -> {
                 cancelTimer()
@@ -119,6 +123,17 @@ class SleepTimerService : Service() {
         if (countdownJob?.isActive == true) {
             remainingMillis += 5 * 60 * 1000L
             totalDurationMillis += 5 * 60 * 1000L
+            updateTimerState(TimerPhase.RUNNING)
+            notificationManager.updateNotification((remainingMillis / 60_000).toInt())
+        }
+    }
+
+    private fun subtractFiveMinutes() {
+        if (countdownJob?.isActive == true) {
+            val fiveMinutesMillis = 5 * 60 * 1000L
+            if (remainingMillis <= fiveMinutesMillis) return
+            remainingMillis -= fiveMinutesMillis
+            totalDurationMillis = (totalDurationMillis - fiveMinutesMillis).coerceAtLeast(remainingMillis)
             updateTimerState(TimerPhase.RUNNING)
             notificationManager.updateNotification((remainingMillis / 60_000).toInt())
         }

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -145,6 +145,11 @@ private fun TimerContent(
 
             Spacer(modifier = Modifier.height(16.dp))
 
+            val runningRemainingSeconds: Int = when (val s = uiState) {
+                is TimerUiState.Running -> s.remainingMinutes * 60 + s.remainingSeconds
+                else -> 0
+            }
+
             ActionRow(
                 isRunning = isRunning,
                 onToggle = {
@@ -162,8 +167,12 @@ private fun TimerContent(
                     }
                 },
                 onMinusFive = {
-                    val next = ((dialState.totalMinutes - 5) / 5) * 5
-                    viewModel.setMinutes(next.coerceAtLeast(0))
+                    if (isRunning) {
+                        viewModel.subtractFiveMinutes()
+                    } else {
+                        val next = ((dialState.totalMinutes - 5) / 5) * 5
+                        viewModel.setMinutes(next.coerceAtLeast(0))
+                    }
                 },
                 onPlusFive = {
                     if (isRunning) {
@@ -173,7 +182,11 @@ private fun TimerContent(
                         viewModel.setMinutes(next.coerceAtMost(300))
                     }
                 },
-                isMinusEnabled = !isRunning && dialState.totalMinutes > 0,
+                isMinusEnabled = if (isRunning) {
+                    runningRemainingSeconds >= 5 * 60
+                } else {
+                    dialState.totalMinutes > 0
+                },
                 isPlusEnabled = !isRunning && dialState.totalMinutes < 300,
                 plusFiveVisibleWhileRunning = true,
             )
@@ -229,16 +242,12 @@ private fun ActionRow(
         horizontalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterHorizontally),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        if (isRunning) {
-            Spacer(modifier = Modifier.size(56.dp))
-        } else {
-            SecondaryRoundButton(
-                icon = Icons.Default.Remove,
-                contentDescription = "Minus 5 minutes",
-                onClick = onMinusFive,
-                enabled = isMinusEnabled,
-            )
-        }
+        SecondaryRoundButton(
+            icon = Icons.Default.Remove,
+            contentDescription = "Minus 5 minutes",
+            onClick = onMinusFive,
+            enabled = isMinusEnabled,
+        )
         PlayButton(isRunning = isRunning, onClick = onToggle)
         SecondaryRoundButton(
             icon = Icons.Default.Add,

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerViewModel.kt
@@ -88,11 +88,20 @@ class TimerViewModel @Inject constructor(
         context.startService(intent)
     }
 
+    fun subtractFiveMinutes() {
+        val intent = Intent().apply {
+            action = ACTION_SUBTRACT_FIVE
+            setClassName(context, SERVICE_CLASS)
+        }
+        context.startService(intent)
+    }
+
     companion object {
         const val SERVICE_CLASS = "dev.mato.sleeptimer.core.service.SleepTimerService"
         const val ACTION_START = "dev.mato.sleeptimer.action.START"
         const val ACTION_CANCEL = "dev.mato.sleeptimer.action.CANCEL"
         const val ACTION_ADD_FIVE = "dev.mato.sleeptimer.action.ADD_FIVE"
+        const val ACTION_SUBTRACT_FIVE = "dev.mato.sleeptimer.action.SUBTRACT_FIVE"
         const val EXTRA_DURATION_MILLIS = "dev.mato.sleeptimer.extra.DURATION_MILLIS"
     }
 }


### PR DESCRIPTION
## Summary
- Minus button now stays visible after the timer starts so a running session can be shortened, not only extended.
- Pressing minus while running subtracts 5 minutes via a new `ACTION_SUBTRACT_FIVE` service action; the button is disabled when less than 5 minutes remain.
- `SleepTimerService.subtractFiveMinutes()` is a no-op if remaining ≤ 5 min and keeps `totalDurationMillis` consistent with `remainingMillis`.

## Test plan
- [ ] Start a 15 min timer, tap minus once → countdown jumps to ~10 min and notification updates.
- [ ] Tap minus repeatedly until < 5 min remain → button becomes greyed out.
- [ ] Tap plus while running → still adds 5 minutes as before.
- [ ] Stop timer and adjust via minus/plus in idle state → unchanged behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)