### PR TITLE
Haptic feedback, button morph, dial slide, heads-up notification

### DIFF
--- a/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/util/TimerDisplay.kt
+++ b/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/util/TimerDisplay.kt
@@ -1,0 +1,13 @@
+package dev.mato.sleeptimer.core.data.util
+
+/**
+ * Converts a remaining duration to the minutes count shown to the user.
+ *
+ * Uses ceiling rounding: while any fractional minute is left, the displayed number
+ * stays one higher — so a fresh 30-minute timer shows "30" for the first 60 seconds,
+ * not "29" after the first tick.
+ */
+fun remainingMillisToDisplayMinutes(remainingMillis: Long): Int {
+    if (remainingMillis <= 0L) return 0
+    return ((remainingMillis + 59_999L) / 60_000L).toInt()
+}

--- a/core/service/src/main/kotlin/dev/mato/sleeptimer/core/service/SleepTimerService.kt
+++ b/core/service/src/main/kotlin/dev/mato/sleeptimer/core/service/SleepTimerService.kt
@@ -12,6 +12,7 @@ import dev.mato.sleeptimer.core.data.model.TimerState
 import dev.mato.sleeptimer.core.data.model.UserSettings
 import dev.mato.sleeptimer.core.data.repository.SettingsRepository
 import dev.mato.sleeptimer.core.data.repository.TimerRepository
+import dev.mato.sleeptimer.core.data.util.remainingMillisToDisplayMinutes
 import dev.mato.sleeptimer.core.service.media.MediaVolumeController
 import dev.mato.sleeptimer.core.service.notification.TimerNotificationManager
 import dev.mato.sleeptimer.core.service.screen.ScreenLockHelper
@@ -80,7 +81,7 @@ class SleepTimerService : Service() {
         // Create notification channel and start foreground
         notificationManager.createNotificationChannel()
         val notification = notificationManager.buildNotification(
-            remainingMinutes = (remainingMillis / 60_000).toInt(),
+            remainingMinutes = remainingMillisToDisplayMinutes(remainingMillis),
         )
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -109,7 +110,7 @@ class SleepTimerService : Service() {
 
                 updateTimerState(TimerPhase.RUNNING)
 
-                val remainingMinutes = (remainingMillis / 60_000).toInt()
+                val remainingMinutes = remainingMillisToDisplayMinutes(remainingMillis)
                 notificationManager.updateNotification(remainingMinutes)
             }
 
@@ -123,7 +124,7 @@ class SleepTimerService : Service() {
             remainingMillis += 5 * 60 * 1000L
             totalDurationMillis += 5 * 60 * 1000L
             updateTimerState(TimerPhase.RUNNING)
-            notificationManager.updateNotification((remainingMillis / 60_000).toInt())
+            notificationManager.updateNotification(remainingMillisToDisplayMinutes(remainingMillis))
         }
     }
 
@@ -134,7 +135,7 @@ class SleepTimerService : Service() {
             remainingMillis -= fiveMinutesMillis
             totalDurationMillis = (totalDurationMillis - fiveMinutesMillis).coerceAtLeast(remainingMillis)
             updateTimerState(TimerPhase.RUNNING)
-            notificationManager.updateNotification((remainingMillis / 60_000).toInt())
+            notificationManager.updateNotification(remainingMillisToDisplayMinutes(remainingMillis))
         }
     }
 

--- a/core/service/src/main/kotlin/dev/mato/sleeptimer/core/service/notification/TimerNotificationManager.kt
+++ b/core/service/src/main/kotlin/dev/mato/sleeptimer/core/service/notification/TimerNotificationManager.kt
@@ -17,9 +17,11 @@ class TimerNotificationManager @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
     companion object {
-        const val CHANNEL_ID = "sleep_timer"
+        const val CHANNEL_ID = "sleep_timer_v2"
+        private const val LEGACY_CHANNEL_ID = "sleep_timer"
         const val NOTIFICATION_ID = 1
         private const val ACTION_ADD_FIVE = "dev.mato.sleeptimer.action.ADD_FIVE"
+        private const val ACTION_SUBTRACT_FIVE = "dev.mato.sleeptimer.action.SUBTRACT_FIVE"
         private const val ACTION_CANCEL = "dev.mato.sleeptimer.action.CANCEL"
         private const val SERVICE_CLASS = "dev.mato.sleeptimer.core.service.SleepTimerService"
     }
@@ -28,13 +30,17 @@ class TimerNotificationManager @Inject constructor(
         context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
     fun createNotificationChannel() {
+        notificationManager.deleteNotificationChannel(LEGACY_CHANNEL_ID)
         val channel = NotificationChannel(
             CHANNEL_ID,
             context.getString(R.string.notification_channel_name),
-            NotificationManager.IMPORTANCE_LOW,
+            NotificationManager.IMPORTANCE_HIGH,
         ).apply {
             description = context.getString(R.string.notification_channel_description)
             setShowBadge(false)
+            setSound(null, null)
+            enableVibration(false)
+            enableLights(false)
         }
         notificationManager.createNotificationChannel(channel)
     }
@@ -58,29 +64,9 @@ class TimerNotificationManager @Inject constructor(
                 )
             }
 
-        // +5 min action
-        val addFiveIntent = Intent().apply {
-            action = ACTION_ADD_FIVE
-            setClassName(context, SERVICE_CLASS)
-        }
-        val addFivePendingIntent = PendingIntent.getService(
-            context,
-            1,
-            addFiveIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-        )
-
-        // Cancel action
-        val cancelIntent = Intent().apply {
-            action = ACTION_CANCEL
-            setClassName(context, SERVICE_CLASS)
-        }
-        val cancelPendingIntent = PendingIntent.getService(
-            context,
-            2,
-            cancelIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-        )
+        val subtractFivePendingIntent = servicePendingIntent(ACTION_SUBTRACT_FIVE, requestCode = 1)
+        val addFivePendingIntent = servicePendingIntent(ACTION_ADD_FIVE, requestCode = 2)
+        val cancelPendingIntent = servicePendingIntent(ACTION_CANCEL, requestCode = 3)
 
         return NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_timer)
@@ -88,11 +74,27 @@ class TimerNotificationManager @Inject constructor(
             .setContentText(contentText)
             .setContentIntent(contentIntent)
             .setOngoing(true)
-            .setSilent(true)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_ALARM)
+            .addAction(0, context.getString(R.string.notification_action_subtract_five), subtractFivePendingIntent)
             .addAction(0, context.getString(R.string.notification_action_add_five), addFivePendingIntent)
             .addAction(0, context.getString(R.string.notification_action_cancel), cancelPendingIntent)
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
             .build()
+    }
+
+    private fun servicePendingIntent(actionName: String, requestCode: Int): PendingIntent {
+        val intent = Intent().apply {
+            action = actionName
+            setClassName(context, SERVICE_CLASS)
+        }
+        return PendingIntent.getService(
+            context,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
     }
 
     fun updateNotification(remainingMinutes: Int) {

--- a/core/service/src/main/res/values-de/strings.xml
+++ b/core/service/src/main/res/values-de/strings.xml
@@ -6,5 +6,6 @@
     <string name="notification_minutes_remaining">Noch %d Minuten</string>
     <string name="notification_less_than_minute">Weniger als eine Minute verbleibend</string>
     <string name="notification_action_add_five">+5 Min</string>
+    <string name="notification_action_subtract_five">-5 Min</string>
     <string name="notification_action_cancel">Abbrechen</string>
 </resources>

--- a/core/service/src/main/res/values/strings.xml
+++ b/core/service/src/main/res/values/strings.xml
@@ -6,5 +6,6 @@
     <string name="notification_minutes_remaining">%d minutes remaining</string>
     <string name="notification_less_than_minute">Less than a minute remaining</string>
     <string name="notification_action_add_five">+5 min</string>
+    <string name="notification_action_subtract_five">-5 min</string>
     <string name="notification_action_cancel">Cancel</string>
 </resources>

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.mato.sleeptimer.core.data.util.remainingMillisToDisplayMinutes
 import dev.mato.sleeptimer.feature.timer.R
 import dev.mato.sleeptimer.feature.timer.theme.AppThemes
 import dev.mato.sleeptimer.feature.timer.theme.LocalAppTheme
@@ -91,7 +92,7 @@ private fun TimerContent(
     }
 
     val runningMinutes: Float = when (val s = uiState) {
-        is TimerUiState.Running -> s.remainingMinutes + s.remainingSeconds / 60f
+        is TimerUiState.Running -> s.remainingMillis / 60_000f
         is TimerUiState.FadingOut -> 0f
         else -> 0f
     }
@@ -130,7 +131,7 @@ private fun TimerContent(
                 when (val s = uiState) {
                     is TimerUiState.Idle -> TimeDisplay(totalMinutes = s.selectedMinutes)
                     is TimerUiState.Running -> TimeDisplay(
-                        totalMinutes = s.remainingMinutes + if (s.remainingSeconds > 0) 1 else 0,
+                        totalMinutes = remainingMillisToDisplayMinutes(s.remainingMillis),
                     )
                     is TimerUiState.FadingOut -> TimeDisplay(totalMinutes = 0)
                 }
@@ -139,12 +140,13 @@ private fun TimerContent(
             Spacer(modifier = Modifier.height(16.dp))
 
             val runningRemainingSeconds: Int = when (val s = uiState) {
-                is TimerUiState.Running -> s.remainingMinutes * 60 + s.remainingSeconds
+                is TimerUiState.Running -> (s.remainingMillis / 1000L).toInt()
                 else -> 0
             }
 
             ActionRow(
                 isRunning = isRunning,
+                hapticEnabled = settings.hapticFeedbackEnabled,
                 onToggle = {
                     if (isRunning) {
                         viewModel.stopTimer()
@@ -221,6 +223,7 @@ private fun HomeTopBar(onOpenSettings: () -> Unit) {
 @Composable
 private fun ActionRow(
     isRunning: Boolean,
+    hapticEnabled: Boolean,
     onToggle: () -> Unit,
     onMinusFive: () -> Unit,
     onPlusFive: () -> Unit,
@@ -239,13 +242,19 @@ private fun ActionRow(
             icon = Icons.Default.Remove,
             contentDescription = "Minus 5 minutes",
             onClick = onMinusFive,
+            hapticEnabled = hapticEnabled,
             enabled = isMinusEnabled,
         )
-        PlayButton(isRunning = isRunning, onClick = onToggle)
+        PlayButton(
+            isRunning = isRunning,
+            hapticEnabled = hapticEnabled,
+            onClick = onToggle,
+        )
         SecondaryRoundButton(
             icon = Icons.Default.Add,
             contentDescription = "Plus 5 minutes",
             onClick = onPlusFive,
+            hapticEnabled = hapticEnabled,
             enabled = if (isRunning) plusFiveVisibleWhileRunning else isPlusEnabled,
         )
     }

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerUiState.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerUiState.kt
@@ -8,8 +8,7 @@ sealed interface TimerUiState {
 
     data class Running(
         val totalMinutes: Int,
-        val remainingMinutes: Int,
-        val remainingSeconds: Int,
+        val remainingMillis: Long,
         val progress: Float,
     ) : TimerUiState
 

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerViewModel.kt
@@ -38,17 +38,15 @@ class TimerViewModel @Inject constructor(
                 TimerUiState.Idle(selectedMinutes = selectedMin)
             }
             TimerPhase.RUNNING -> {
-                val remainingSeconds = (timerState.remainingMillis / 1000).toInt()
                 val totalSeconds = (timerState.totalDurationMillis / 1000).toInt()
-                val progress = if (totalSeconds > 0) {
-                    remainingSeconds.toFloat() / totalSeconds.toFloat()
+                val progress = if (timerState.totalDurationMillis > 0L) {
+                    timerState.remainingMillis.toFloat() / timerState.totalDurationMillis.toFloat()
                 } else {
                     0f
                 }
                 TimerUiState.Running(
                     totalMinutes = (totalSeconds / 60),
-                    remainingMinutes = remainingSeconds / 60,
-                    remainingSeconds = remainingSeconds % 60,
+                    remainingMillis = timerState.remainingMillis,
                     progress = progress,
                 )
             }

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/components/CircularDial.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/components/CircularDial.kt
@@ -2,12 +2,16 @@ package dev.mato.sleeptimer.feature.timer.timer.components
 
 import android.os.Build
 import android.view.HapticFeedbackConstants
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -49,7 +53,22 @@ fun CircularDial(
     }
     var lastReportedMinutes by remember { mutableStateOf(state.totalMinutes) }
 
-    val displayMinutes: Float = if (isRunning) runningMinutes else state.totalMinutes.toFloat()
+    val targetMinutes: Float = if (isRunning) runningMinutes else state.totalMinutes.toFloat()
+    val animatedMinutes = remember { Animatable(targetMinutes) }
+    LaunchedEffect(targetMinutes, state.isDragging) {
+        val delta = kotlin.math.abs(targetMinutes - animatedMinutes.value)
+        val snap = state.isDragging || delta < 1f
+        if (snap) {
+            animatedMinutes.snapTo(targetMinutes)
+        } else {
+            animatedMinutes.animateTo(
+                targetValue = targetMinutes,
+                animationSpec = tween(durationMillis = 360, easing = FastOutSlowInEasing),
+            )
+        }
+    }
+
+    val displayMinutes: Float = animatedMinutes.value
     val minuteInRing = ((displayMinutes % 60f) + 60f) % 60f
     val ringFraction = minuteInRing / 60f
     val hoursComplete = (displayMinutes / 60f).toInt().coerceIn(0, 5)

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/components/CircularDialState.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/components/CircularDialState.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import kotlin.math.atan2
@@ -16,9 +17,10 @@ class CircularDialState {
         private set
     var totalMinutes by mutableIntStateOf(15)
         private set
+    var isDragging by mutableStateOf(false)
+        private set
 
     private var previousAngle = 90f
-    private var isDragging = false
     private var cumulativeDegrees = 0f
 
     val maxRevolutions = 5 // 5 hours

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/components/PlayButton.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/components/PlayButton.kt
@@ -1,24 +1,33 @@
 package dev.mato.sleeptimer.feature.timer.timer.components
 
+import android.os.Build
+import android.view.HapticFeedbackConstants
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import dev.mato.sleeptimer.feature.timer.R
@@ -27,59 +36,77 @@ import dev.mato.sleeptimer.feature.timer.theme.appTheme
 @Composable
 fun PlayButton(
     isRunning: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val icon: ImageVector = if (isRunning) Icons.Default.Stop else Icons.Default.PlayArrow
-    val desc = stringResource(if (isRunning) R.string.stop_timer else R.string.start_timer)
-    RoundAccentButton(icon = icon, contentDescription = desc, onClick = onClick, modifier = modifier)
-}
-
-@Composable
-fun RoundAccentButton(
-    icon: ImageVector,
-    contentDescription: String?,
+    hapticEnabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val theme = appTheme()
+    val view = LocalView.current
+
+    val morph by animateFloatAsState(
+        targetValue = if (isRunning) 1f else 0f,
+        animationSpec = tween(durationMillis = 240, easing = FastOutSlowInEasing),
+        label = "playMorph",
+    )
+    // 0 = circle (50% corners), 1 = rounded square (~28% corners)
+    val cornerPercent = (50f - 22f * morph).toInt().coerceIn(28, 50)
+    val shape = RoundedCornerShape(percent = cornerPercent)
+
     val shadowModifier = if (theme.hasGradient) {
         Modifier.shadow(
             elevation = 20.dp,
-            shape = CircleShape,
+            shape = shape,
             ambientColor = theme.accent,
             spotColor = theme.accent,
         )
     } else {
         Modifier
     }
+
     Box(
         modifier = modifier
             .size(84.dp)
             .then(shadowModifier)
-            .clip(CircleShape)
-            .clickable(onClick = onClick),
+            .clip(shape)
+            .clickable {
+                if (hapticEnabled) {
+                    view.performHapticFeedback(playStopHaptic)
+                }
+                onClick()
+            },
         contentAlignment = Alignment.Center,
     ) {
         Canvas(modifier = Modifier.size(84.dp)) {
-            drawCircle(color = theme.accent)
-            drawCircle(
+            val cornerRadiusPx = (cornerPercent / 100f) * size.minDimension
+            val corner = CornerRadius(cornerRadiusPx, cornerRadiusPx)
+            drawRoundRect(
+                color = theme.accent,
+                cornerRadius = corner,
+            )
+            drawRoundRect(
                 brush = Brush.verticalGradient(
                     0f to Color.White.copy(alpha = if (theme.isDark) 0.45f else 0.30f),
                     1f to Color.White.copy(alpha = 0f),
                     startY = 0f,
                     endY = size.height * 0.55f,
                 ),
-                radius = size.minDimension / 2f - 1.dp.toPx(),
-                center = Offset(size.width / 2f, size.height / 2f),
+                cornerRadius = corner,
             )
         }
-        Icon(
-            imageVector = icon,
-            contentDescription = contentDescription,
-            tint = theme.accentInk,
-            modifier = Modifier.size(34.dp),
-        )
+        Crossfade(
+            targetState = isRunning,
+            animationSpec = tween(durationMillis = 180),
+            label = "playIcon",
+        ) { running ->
+            val icon: ImageVector = if (running) Icons.Default.Stop else Icons.Default.PlayArrow
+            val desc = stringResource(if (running) R.string.stop_timer else R.string.start_timer)
+            Icon(
+                imageVector = icon,
+                contentDescription = desc,
+                tint = theme.accentInk,
+                modifier = Modifier.size(34.dp),
+            )
+        }
     }
 }
 
@@ -88,15 +115,22 @@ fun SecondaryRoundButton(
     icon: ImageVector,
     contentDescription: String?,
     onClick: () -> Unit,
+    hapticEnabled: Boolean,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
 ) {
     val theme = appTheme()
+    val view = LocalView.current
     Box(
         modifier = modifier
             .size(56.dp)
             .clip(CircleShape)
-            .clickable(enabled = enabled, onClick = onClick),
+            .clickable(enabled = enabled) {
+                if (hapticEnabled) {
+                    view.performHapticFeedback(stepHaptic)
+                }
+                onClick()
+            },
         contentAlignment = Alignment.Center,
     ) {
         Canvas(modifier = Modifier.size(56.dp)) {
@@ -111,3 +145,13 @@ fun SecondaryRoundButton(
         )
     }
 }
+
+private val playStopHaptic: Int
+    get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        HapticFeedbackConstants.CONFIRM
+    } else {
+        HapticFeedbackConstants.VIRTUAL_KEY
+    }
+
+private val stepHaptic: Int
+    get() = HapticFeedbackConstants.CLOCK_TICK


### PR DESCRIPTION
## Summary

- **Haptics**: play/stop (`CONFIRM`) and +/- (`CLOCK_TICK`) now trigger haptic feedback, gated by the existing `hapticFeedbackEnabled` setting
- **Play button morph**: circle (idle) ↔ rounded square (running), 240ms `FastOutSlowInEasing`; play/stop icons crossfade
- **Dial slide**: smooth animation on +/- jumps whether the timer is idle or running; countdown ticks snap. Single source of truth via `Animatable`, threshold-based snap/animate (δ<1 min → snap; dragging → snap)
- **Heads-up notification**: appears once on start only (`setOnlyAlertOnce`), ported to a fresh channel (`sleep_timer_v2`, `IMPORTANCE_HIGH`, sound/vibration disabled). Previous `setSilent(true)` was suppressing heads-up
- **-5 min action** added to the notification, placed before +5
- **`remainingMillisToDisplayMinutes`** helper in `core:data` fixes the "30 → 29 after one second" rounding bug in the notification and unifies the ceiling logic with the on-dial time display. `TimerUiState.Running` now carries `remainingMillis` instead of derived `remainingMinutes`/`remainingSeconds`

## Test plan

- [ ] Haptic: play/stop feels distinct from +/-; silenced when `hapticFeedbackEnabled=false`
- [ ] Play button: morphs between circle and rounded square on start/stop; shadow follows the shape
- [ ] Dial: +5/-5 slides smoothly both idle and while running; drag feels immediate (no slide lag); countdown motion unchanged
- [ ] Notification: heads-up appears on Start only, not on every second; no sound, no vibration
- [ ] Notification actions: -5 | +5 | Cancel shown in that order, all fire correctly
- [ ] Notification minute count shows starting value (e.g. 30) for the first 60 seconds, not 29 after the first tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)