### PR TITLE
Make +/- button step configurable

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -28,7 +28,7 @@
     <string name="notification_content_title">Schlaf-Timer</string>
     <string name="notification_minutes_remaining">Noch %d Minuten</string>
     <string name="notification_less_than_minute">Weniger als eine Minute verbleibend</string>
-    <string name="notification_action_add_five">+5 Min</string>
+    <string name="notification_action_add_minutes">+%d Min</string>
     <string name="notification_action_cancel">Abbrechen</string>
 
     <!-- Device Admin -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="notification_content_title">Sleep Timer</string>
     <string name="notification_minutes_remaining">%d minutes remaining</string>
     <string name="notification_less_than_minute">Less than a minute remaining</string>
-    <string name="notification_action_add_five">+5 min</string>
+    <string name="notification_action_add_minutes">+%d min</string>
     <string name="notification_action_cancel">Cancel</string>
 
     <!-- Device Admin -->

--- a/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/model/UserSettings.kt
+++ b/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/model/UserSettings.kt
@@ -7,4 +7,5 @@ data class UserSettings(
     val hapticFeedbackEnabled: Boolean = true,
     val theme: ThemeId = ThemeId.Default,
     val starsEnabled: Boolean = true,
+    val stepMinutes: Int = 5,
 )

--- a/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/repository/SettingsRepository.kt
+++ b/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/repository/SettingsRepository.kt
@@ -12,4 +12,5 @@ interface SettingsRepository {
     suspend fun updateHapticFeedback(enabled: Boolean)
     suspend fun updateTheme(theme: ThemeId)
     suspend fun updateStarsEnabled(enabled: Boolean)
+    suspend fun updateStepMinutes(minutes: Int)
 }

--- a/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/repository/SettingsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/dev/mato/sleeptimer/core/data/repository/SettingsRepositoryImpl.kt
@@ -25,6 +25,7 @@ class SettingsRepositoryImpl @Inject constructor(
         val HAPTIC_FEEDBACK = booleanPreferencesKey("haptic_feedback")
         val THEME = stringPreferencesKey("theme")
         val STARS_ENABLED = booleanPreferencesKey("stars_enabled")
+        val STEP_MINUTES = intPreferencesKey("step_minutes")
     }
 
     override val settings: Flow<UserSettings> = dataStore.data.map { prefs ->
@@ -35,6 +36,7 @@ class SettingsRepositoryImpl @Inject constructor(
             hapticFeedbackEnabled = prefs[HAPTIC_FEEDBACK] ?: true,
             theme = ThemeId.fromStorage(prefs[THEME]),
             starsEnabled = prefs[STARS_ENABLED] ?: true,
+            stepMinutes = prefs[STEP_MINUTES] ?: 5,
         )
     }
 
@@ -60,5 +62,9 @@ class SettingsRepositoryImpl @Inject constructor(
 
     override suspend fun updateStarsEnabled(enabled: Boolean) {
         dataStore.edit { it[STARS_ENABLED] = enabled }
+    }
+
+    override suspend fun updateStepMinutes(minutes: Int) {
+        dataStore.edit { it[STEP_MINUTES] = minutes.coerceIn(1, 30) }
     }
 }

--- a/core/service/src/main/kotlin/dev/mato/sleeptimer/core/service/SleepTimerService.kt
+++ b/core/service/src/main/kotlin/dev/mato/sleeptimer/core/service/SleepTimerService.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -36,15 +37,26 @@ class SleepTimerService : Service() {
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var countdownJob: Job? = null
+    private var settingsJob: Job? = null
     private var remainingMillis: Long = 0L
     private var totalDurationMillis: Long = 0L
+    private var stepMinutes: Int = 5
 
     companion object {
         const val ACTION_START = "dev.mato.sleeptimer.action.START"
         const val ACTION_CANCEL = "dev.mato.sleeptimer.action.CANCEL"
-        const val ACTION_ADD_FIVE = "dev.mato.sleeptimer.action.ADD_FIVE"
-        const val ACTION_SUBTRACT_FIVE = "dev.mato.sleeptimer.action.SUBTRACT_FIVE"
+        const val ACTION_ADD_MINUTES = "dev.mato.sleeptimer.action.ADD_MINUTES"
+        const val ACTION_SUBTRACT_MINUTES = "dev.mato.sleeptimer.action.SUBTRACT_MINUTES"
         const val EXTRA_DURATION_MILLIS = "dev.mato.sleeptimer.extra.DURATION_MILLIS"
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        settingsJob = serviceScope.launch {
+            settingsRepository.settings
+                .map { it.stepMinutes }
+                .collect { stepMinutes = it }
+        }
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -57,11 +69,11 @@ class SleepTimerService : Service() {
                     startTimer(durationMillis)
                 }
             }
-            ACTION_ADD_FIVE -> {
-                addFiveMinutes()
+            ACTION_ADD_MINUTES -> {
+                addStep()
             }
-            ACTION_SUBTRACT_FIVE -> {
-                subtractFiveMinutes()
+            ACTION_SUBTRACT_MINUTES -> {
+                subtractStep()
             }
             ACTION_CANCEL -> {
                 cancelTimer()
@@ -81,6 +93,7 @@ class SleepTimerService : Service() {
         notificationManager.createNotificationChannel()
         val notification = notificationManager.buildNotification(
             remainingMinutes = (remainingMillis / 60_000).toInt(),
+            stepMinutes = stepMinutes,
         )
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -110,7 +123,7 @@ class SleepTimerService : Service() {
                 updateTimerState(TimerPhase.RUNNING)
 
                 val remainingMinutes = (remainingMillis / 60_000).toInt()
-                notificationManager.updateNotification(remainingMinutes)
+                notificationManager.updateNotification(remainingMinutes, stepMinutes)
             }
 
             // Timer expired — handle completion
@@ -118,23 +131,24 @@ class SleepTimerService : Service() {
         }
     }
 
-    private fun addFiveMinutes() {
+    private fun addStep() {
         if (countdownJob?.isActive == true) {
-            remainingMillis += 5 * 60 * 1000L
-            totalDurationMillis += 5 * 60 * 1000L
+            val stepMillis = stepMinutes * 60 * 1000L
+            remainingMillis += stepMillis
+            totalDurationMillis += stepMillis
             updateTimerState(TimerPhase.RUNNING)
-            notificationManager.updateNotification((remainingMillis / 60_000).toInt())
+            notificationManager.updateNotification((remainingMillis / 60_000).toInt(), stepMinutes)
         }
     }
 
-    private fun subtractFiveMinutes() {
+    private fun subtractStep() {
         if (countdownJob?.isActive == true) {
-            val fiveMinutesMillis = 5 * 60 * 1000L
-            if (remainingMillis <= fiveMinutesMillis) return
-            remainingMillis -= fiveMinutesMillis
-            totalDurationMillis = (totalDurationMillis - fiveMinutesMillis).coerceAtLeast(remainingMillis)
+            val stepMillis = stepMinutes * 60 * 1000L
+            if (remainingMillis <= stepMillis) return
+            remainingMillis -= stepMillis
+            totalDurationMillis = (totalDurationMillis - stepMillis).coerceAtLeast(remainingMillis)
             updateTimerState(TimerPhase.RUNNING)
-            notificationManager.updateNotification((remainingMillis / 60_000).toInt())
+            notificationManager.updateNotification((remainingMillis / 60_000).toInt(), stepMinutes)
         }
     }
 
@@ -157,7 +171,7 @@ class SleepTimerService : Service() {
 
             if (settings.stopMediaPlayback) {
                 updateTimerState(TimerPhase.FADING_OUT)
-                notificationManager.updateNotification(0)
+                notificationManager.updateNotification(0, stepMinutes)
 
                 mediaVolumeController.fadeOutAndPause(settings.fadeOutDurationSeconds)
             }

--- a/core/service/src/main/kotlin/dev/mato/sleeptimer/core/service/notification/TimerNotificationManager.kt
+++ b/core/service/src/main/kotlin/dev/mato/sleeptimer/core/service/notification/TimerNotificationManager.kt
@@ -19,7 +19,7 @@ class TimerNotificationManager @Inject constructor(
     companion object {
         const val CHANNEL_ID = "sleep_timer"
         const val NOTIFICATION_ID = 1
-        private const val ACTION_ADD_FIVE = "dev.mato.sleeptimer.action.ADD_FIVE"
+        private const val ACTION_ADD_MINUTES = "dev.mato.sleeptimer.action.ADD_MINUTES"
         private const val ACTION_CANCEL = "dev.mato.sleeptimer.action.CANCEL"
         private const val SERVICE_CLASS = "dev.mato.sleeptimer.core.service.SleepTimerService"
     }
@@ -39,7 +39,7 @@ class TimerNotificationManager @Inject constructor(
         notificationManager.createNotificationChannel(channel)
     }
 
-    fun buildNotification(remainingMinutes: Int): Notification {
+    fun buildNotification(remainingMinutes: Int, stepMinutes: Int): Notification {
         val contentText = if (remainingMinutes > 0) {
             context.getString(R.string.notification_minutes_remaining, remainingMinutes)
         } else {
@@ -58,15 +58,15 @@ class TimerNotificationManager @Inject constructor(
                 )
             }
 
-        // +5 min action
-        val addFiveIntent = Intent().apply {
-            action = ACTION_ADD_FIVE
+        // +minutes action
+        val addMinutesIntent = Intent().apply {
+            action = ACTION_ADD_MINUTES
             setClassName(context, SERVICE_CLASS)
         }
-        val addFivePendingIntent = PendingIntent.getService(
+        val addMinutesPendingIntent = PendingIntent.getService(
             context,
             1,
-            addFiveIntent,
+            addMinutesIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
 
@@ -89,14 +89,18 @@ class TimerNotificationManager @Inject constructor(
             .setContentIntent(contentIntent)
             .setOngoing(true)
             .setSilent(true)
-            .addAction(0, context.getString(R.string.notification_action_add_five), addFivePendingIntent)
+            .addAction(
+                0,
+                context.getString(R.string.notification_action_add_minutes, stepMinutes),
+                addMinutesPendingIntent,
+            )
             .addAction(0, context.getString(R.string.notification_action_cancel), cancelPendingIntent)
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
             .build()
     }
 
-    fun updateNotification(remainingMinutes: Int) {
-        notificationManager.notify(NOTIFICATION_ID, buildNotification(remainingMinutes))
+    fun updateNotification(remainingMinutes: Int, stepMinutes: Int) {
+        notificationManager.notify(NOTIFICATION_ID, buildNotification(remainingMinutes, stepMinutes))
     }
 
     fun cancelNotification() {

--- a/core/service/src/main/res/values-de/strings.xml
+++ b/core/service/src/main/res/values-de/strings.xml
@@ -5,6 +5,6 @@
     <string name="notification_content_title">Schlaf-Timer</string>
     <string name="notification_minutes_remaining">Noch %d Minuten</string>
     <string name="notification_less_than_minute">Weniger als eine Minute verbleibend</string>
-    <string name="notification_action_add_five">+5 Min</string>
+    <string name="notification_action_add_minutes">+%d Min</string>
     <string name="notification_action_cancel">Abbrechen</string>
 </resources>

--- a/core/service/src/main/res/values/strings.xml
+++ b/core/service/src/main/res/values/strings.xml
@@ -5,6 +5,6 @@
     <string name="notification_content_title">Sleep Timer</string>
     <string name="notification_minutes_remaining">%d minutes remaining</string>
     <string name="notification_less_than_minute">Less than a minute remaining</string>
-    <string name="notification_action_add_five">+5 min</string>
+    <string name="notification_action_add_minutes">+%d min</string>
     <string name="notification_action_cancel">Cancel</string>
 </resources>

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/settings/SettingsScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/settings/SettingsScreen.kt
@@ -42,6 +42,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.mato.sleeptimer.feature.timer.R
 import dev.mato.sleeptimer.feature.timer.settings.components.FadeOutSlider
 import dev.mato.sleeptimer.feature.timer.settings.components.SettingsToggleRow
+import dev.mato.sleeptimer.feature.timer.settings.components.StepMinutesSlider
 import dev.mato.sleeptimer.feature.timer.settings.components.ThemeSelector
 import dev.mato.sleeptimer.feature.timer.theme.AppThemes
 import dev.mato.sleeptimer.feature.timer.theme.LocalAppTheme
@@ -126,6 +127,10 @@ private fun SettingsContent(
                 FadeOutSlider(
                     durationSeconds = uiState.settings.fadeOutDurationSeconds,
                     onDurationChanged = { viewModel.updateFadeOutDuration(it) },
+                )
+                StepMinutesSlider(
+                    stepMinutes = uiState.settings.stepMinutes,
+                    onStepChanged = { viewModel.updateStepMinutes(it) },
                 )
 
                 Spacer(modifier = Modifier.height(4.dp))

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/settings/SettingsViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/settings/SettingsViewModel.kt
@@ -67,4 +67,8 @@ class SettingsViewModel @Inject constructor(
     fun updateStarsEnabled(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.updateStarsEnabled(enabled) }
     }
+
+    fun updateStepMinutes(minutes: Int) {
+        viewModelScope.launch { settingsRepository.updateStepMinutes(minutes) }
+    }
 }

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/settings/components/StepMinutesSlider.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/settings/components/StepMinutesSlider.kt
@@ -1,0 +1,76 @@
+package dev.mato.sleeptimer.feature.timer.settings.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import dev.mato.sleeptimer.feature.timer.R
+import dev.mato.sleeptimer.feature.timer.theme.appTheme
+import kotlin.math.roundToInt
+
+@Composable
+fun StepMinutesSlider(
+    stepMinutes: Int,
+    onStepChanged: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val theme = appTheme()
+    var sliderValue by remember(stepMinutes) { mutableFloatStateOf(stepMinutes.toFloat()) }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 8.dp)
+            .clip(RoundedCornerShape(18.dp))
+            .background(theme.surface1)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(R.string.step_minutes_title),
+                style = MaterialTheme.typography.titleMedium,
+                color = theme.textPrimary,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = stringResource(R.string.step_minutes_value, sliderValue.roundToInt()),
+                style = MaterialTheme.typography.bodyMedium,
+                color = theme.accent,
+            )
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Slider(
+            value = sliderValue,
+            onValueChange = { sliderValue = it },
+            onValueChangeFinished = { onStepChanged(sliderValue.roundToInt()) },
+            valueRange = 1f..30f,
+            steps = 28,
+            colors = SliderDefaults.colors(
+                thumbColor = theme.accent,
+                activeTrackColor = theme.accent,
+                inactiveTrackColor = theme.stroke,
+                activeTickColor = theme.accent,
+                inactiveTickColor = theme.stroke,
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -159,29 +159,33 @@ private fun TimerContent(
                         viewModel.startTimer()
                     }
                 },
-                onMinusFive = {
+                onMinusStep = {
                     if (isRunning) {
-                        viewModel.subtractFiveMinutes()
+                        viewModel.subtractStep()
                     } else {
-                        val next = ((dialState.totalMinutes - 5) / 5) * 5
-                        viewModel.setMinutes(next.coerceAtLeast(0))
+                        val step = settings.stepMinutes
+                        val current = dialState.totalMinutes
+                        val next = ((current - 1).coerceAtLeast(0) / step) * step
+                        viewModel.setMinutes(next)
                     }
                 },
-                onPlusFive = {
+                onPlusStep = {
                     if (isRunning) {
-                        viewModel.addFiveMinutes()
+                        viewModel.addStep()
                     } else {
-                        val next = ((dialState.totalMinutes + 5) / 5) * 5
+                        val step = settings.stepMinutes
+                        val current = dialState.totalMinutes
+                        val next = (current / step + 1) * step
                         viewModel.setMinutes(next.coerceAtMost(300))
                     }
                 },
                 isMinusEnabled = if (isRunning) {
-                    runningRemainingSeconds >= 5 * 60
+                    runningRemainingSeconds > settings.stepMinutes * 60
                 } else {
                     dialState.totalMinutes > 0
                 },
                 isPlusEnabled = !isRunning && dialState.totalMinutes < 300,
-                plusFiveVisibleWhileRunning = true,
+                plusStepVisibleWhileRunning = true,
             )
 
             Spacer(modifier = Modifier.height(32.dp))
@@ -222,11 +226,11 @@ private fun HomeTopBar(onOpenSettings: () -> Unit) {
 private fun ActionRow(
     isRunning: Boolean,
     onToggle: () -> Unit,
-    onMinusFive: () -> Unit,
-    onPlusFive: () -> Unit,
+    onMinusStep: () -> Unit,
+    onPlusStep: () -> Unit,
     isMinusEnabled: Boolean,
     isPlusEnabled: Boolean,
-    plusFiveVisibleWhileRunning: Boolean,
+    plusStepVisibleWhileRunning: Boolean,
 ) {
     androidx.compose.foundation.layout.Row(
         modifier = Modifier
@@ -237,16 +241,16 @@ private fun ActionRow(
     ) {
         SecondaryRoundButton(
             icon = Icons.Default.Remove,
-            contentDescription = "Minus 5 minutes",
-            onClick = onMinusFive,
+            contentDescription = "Minus",
+            onClick = onMinusStep,
             enabled = isMinusEnabled,
         )
         PlayButton(isRunning = isRunning, onClick = onToggle)
         SecondaryRoundButton(
             icon = Icons.Default.Add,
-            contentDescription = "Plus 5 minutes",
-            onClick = onPlusFive,
-            enabled = if (isRunning) plusFiveVisibleWhileRunning else isPlusEnabled,
+            contentDescription = "Plus",
+            onClick = onPlusStep,
+            enabled = if (isRunning) plusStepVisibleWhileRunning else isPlusEnabled,
         )
     }
 }

--- a/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/mato/sleeptimer/feature/timer/timer/TimerViewModel.kt
@@ -80,17 +80,17 @@ class TimerViewModel @Inject constructor(
         context.startService(intent)
     }
 
-    fun addFiveMinutes() {
+    fun addStep() {
         val intent = Intent().apply {
-            action = ACTION_ADD_FIVE
+            action = ACTION_ADD_MINUTES
             setClassName(context, SERVICE_CLASS)
         }
         context.startService(intent)
     }
 
-    fun subtractFiveMinutes() {
+    fun subtractStep() {
         val intent = Intent().apply {
-            action = ACTION_SUBTRACT_FIVE
+            action = ACTION_SUBTRACT_MINUTES
             setClassName(context, SERVICE_CLASS)
         }
         context.startService(intent)
@@ -100,8 +100,8 @@ class TimerViewModel @Inject constructor(
         const val SERVICE_CLASS = "dev.mato.sleeptimer.core.service.SleepTimerService"
         const val ACTION_START = "dev.mato.sleeptimer.action.START"
         const val ACTION_CANCEL = "dev.mato.sleeptimer.action.CANCEL"
-        const val ACTION_ADD_FIVE = "dev.mato.sleeptimer.action.ADD_FIVE"
-        const val ACTION_SUBTRACT_FIVE = "dev.mato.sleeptimer.action.SUBTRACT_FIVE"
+        const val ACTION_ADD_MINUTES = "dev.mato.sleeptimer.action.ADD_MINUTES"
+        const val ACTION_SUBTRACT_MINUTES = "dev.mato.sleeptimer.action.SUBTRACT_MINUTES"
         const val EXTRA_DURATION_MILLIS = "dev.mato.sleeptimer.extra.DURATION_MILLIS"
     }
 }

--- a/feature/timer/src/main/res/values-de/strings.xml
+++ b/feature/timer/src/main/res/values-de/strings.xml
@@ -17,6 +17,8 @@
     <string name="playback_description">Audio- und Videowiedergabe stoppen</string>
     <string name="fade_out_title">Fade-out-Dauer</string>
     <string name="fade_out_seconds">%d Sekunden</string>
+    <string name="step_minutes_title">+/− Schrittweite</string>
+    <string name="step_minutes_value">%d Min</string>
     <string name="screen_title">Bildschirm</string>
     <string name="screen_description">Bildschirm sperren wenn Timer endet</string>
     <string name="screen_admin_required">Geräteadministrator-Berechtigung erforderlich</string>

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -17,6 +17,8 @@
     <string name="playback_description">Stop audio and video playback</string>
     <string name="fade_out_title">Fade-out duration</string>
     <string name="fade_out_seconds">%d seconds</string>
+    <string name="step_minutes_title">+/− step</string>
+    <string name="step_minutes_value">%d min</string>
     <string name="screen_title">Screen</string>
     <string name="screen_description">Lock screen when timer ends</string>
     <string name="screen_admin_required">Device admin permission required</string>


### PR DESCRIPTION
## Summary
- New **+/− step** setting (1–30 min, default 5) exposed as a slider in the Sleep Timer settings section, styled like the existing fade-out slider.
- `SleepTimerService` now observes `UserSettings.stepMinutes` and uses it for add/subtract while a timer is running; the notification action label reflects the current value (e.g. `+10 min`) and updates live if the setting changes mid-timer.
- Idle-mode +/− snaps to the nearest lower/higher multiple of the step — e.g. with step 5, `9 → 5` on minus and `9 → 10` on plus (previously `9` would jump straight to `0` or `10` inconsistently).
- Renamed the internal actions `ACTION_ADD_FIVE` / `ACTION_SUBTRACT_FIVE` to `ACTION_ADD_MINUTES` / `ACTION_SUBTRACT_MINUTES` and the ViewModel methods to `addStep` / `subtractStep`.

## Test plan
- [ ] Open Settings → Sleep Timer → slide **+/− step** to 10 min; back on the timer, `+` adds 10 and `−` subtracts 10.
- [ ] Set step to 1 min; `+`/`−` change the dial by 1 minute each press.
- [ ] Idle, set dial to 9 min with step 5 → `−` goes to 5, `+` goes to 10.
- [ ] Idle, set dial to 14 min with step 5 → `−` goes to 10, `+` goes to 15.
- [ ] Start a 20 min timer with step 5, change step to 10 in settings without cancelling → notification action shows `+10 min`, tapping it adds 10.
- [ ] Running timer, step 10, ≤ 10 min remaining → minus button disabled.
- [ ] Fresh install: default step is 5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)