### PR TITLE
Localize hardcoded UI strings

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_name">SleepTimer</string>
 
     <!-- Timer Screen -->
-    <string name="minutes_label">MINUTEN</string>
     <string name="start_timer">Timer starten</string>
     <string name="stop_timer">Timer stoppen</string>
     <string name="settings">Einstellungen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,6 @@
     <string name="app_name">SleepTimer</string>
 
     <!-- Timer Screen -->
-    <string name="minutes_label">MINUTES</string>
     <string name="start_timer">Start timer</string>
     <string name="stop_timer">Stop timer</string>
     <string name="settings">Settings</string>

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/ThemeSelector.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/ThemeSelector.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.xitee.sleeptimer.core.data.model.ThemeId
@@ -82,7 +83,7 @@ private fun ThemeCard(
         ThemePreview(option)
         Spacer(modifier = Modifier.height(8.dp))
         Text(
-            text = option.label,
+            text = stringResource(option.labelRes),
             style = MaterialTheme.typography.bodyMedium.copy(
                 fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
             ),

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/theme/AppTheme.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/theme/AppTheme.kt
@@ -1,5 +1,6 @@
 package dev.xitee.sleeptimer.feature.timer.theme
 
+import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
@@ -13,7 +14,7 @@ import dev.xitee.sleeptimer.core.data.model.ThemeId
  */
 data class AppTheme(
     val id: ThemeId,
-    val label: String,
+    @StringRes val labelRes: Int,
 
     // Background
     val hasGradient: Boolean,

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/theme/AppThemes.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/theme/AppThemes.kt
@@ -2,12 +2,13 @@ package dev.xitee.sleeptimer.feature.timer.theme
 
 import androidx.compose.ui.graphics.Color
 import dev.xitee.sleeptimer.core.data.model.ThemeId
+import dev.xitee.sleeptimer.feature.timer.R
 
 object AppThemes {
 
     val Midnight: AppTheme = darkThemeOf(
         id = ThemeId.Midnight,
-        label = "Midnight",
+        labelRes = R.string.theme_midnight,
         bgTop = Color(0xFF2A2550),
         bgMid = Color(0xFF1A1830),
         bgBot = Color(0xFF0F0D1F),
@@ -16,7 +17,7 @@ object AppThemes {
 
     val Ocean: AppTheme = darkThemeOf(
         id = ThemeId.Ocean,
-        label = "Ocean",
+        labelRes = R.string.theme_ocean,
         bgTop = Color(0xFF0F3A55),
         bgMid = Color(0xFF0A2438),
         bgBot = Color(0xFF05121E),
@@ -25,7 +26,7 @@ object AppThemes {
 
     val Ember: AppTheme = darkThemeOf(
         id = ThemeId.Ember,
-        label = "Ember",
+        labelRes = R.string.theme_ember,
         bgTop = Color(0xFF3A1810),
         bgMid = Color(0xFF22110A),
         bgBot = Color(0xFF0E0705),
@@ -34,7 +35,7 @@ object AppThemes {
 
     val Light: AppTheme = AppTheme(
         id = ThemeId.Light,
-        label = "Light",
+        labelRes = R.string.theme_light,
         hasGradient = true,
         bgTop = Color(0xFFF4F1EC),
         bgMid = Color(0xFFEAE4DA),
@@ -66,7 +67,7 @@ object AppThemes {
 
     val Basic: AppTheme = darkThemeOf(
         id = ThemeId.Basic,
-        label = "Basic",
+        labelRes = R.string.theme_basic,
         bgTop = Color(0xFF1B1B1F),
         bgMid = Color(0xFF1B1B1F),
         bgBot = Color(0xFF1B1B1F),
@@ -91,14 +92,14 @@ object AppThemes {
 /** Factory for dark-on-gradient themes that only differ in their 3 gradient stops + accent. */
 private fun darkThemeOf(
     id: ThemeId,
-    label: String,
+    labelRes: Int,
     bgTop: Color,
     bgMid: Color,
     bgBot: Color,
     accent: Color,
 ): AppTheme = AppTheme(
     id = id,
-    label = label,
+    labelRes = labelRes,
     hasGradient = true,
     bgTop = bgTop,
     bgMid = bgMid,

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -244,7 +244,7 @@ private fun ActionRow(
     ) {
         SecondaryRoundButton(
             icon = Icons.Default.Remove,
-            contentDescription = "Minus",
+            contentDescription = stringResource(R.string.cd_step_minus),
             onClick = onMinusStep,
             hapticEnabled = hapticEnabled,
             enabled = isMinusEnabled,
@@ -256,7 +256,7 @@ private fun ActionRow(
         )
         SecondaryRoundButton(
             icon = Icons.Default.Add,
-            contentDescription = "Plus",
+            contentDescription = stringResource(R.string.cd_step_plus),
             onClick = onPlusStep,
             hapticEnabled = hapticEnabled,
             enabled = if (isRunning) plusStepVisibleWhileRunning else isPlusEnabled,

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/components/TimeDisplay.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/components/TimeDisplay.kt
@@ -8,7 +8,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import dev.xitee.sleeptimer.feature.timer.R
 import dev.xitee.sleeptimer.feature.timer.theme.appTheme
 
 @Composable
@@ -25,15 +27,19 @@ fun TimeDisplay(
     when {
         hours == 0 -> {
             big = remMin.toString()
-            small = if (remMin == 1) "minute" else "minutes"
+            small = stringResource(
+                if (remMin == 1) R.string.time_unit_minute else R.string.time_unit_minutes,
+            )
         }
         remMin == 0 -> {
             big = hours.toString()
-            small = if (hours == 1) "hour" else "hours"
+            small = stringResource(
+                if (hours == 1) R.string.time_unit_hour else R.string.time_unit_hours,
+            )
         }
         else -> {
             big = "$hours:${remMin.toString().padStart(2, '0')}"
-            small = "hr · min"
+            small = stringResource(R.string.time_unit_hr_min)
         }
     }
 

--- a/feature/timer/src/main/res/values-de/strings.xml
+++ b/feature/timer/src/main/res/values-de/strings.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SleepTimer</string>
-    <string name="minutes_label">MINUTEN</string>
     <string name="start_timer">Timer starten</string>
     <string name="stop_timer">Timer stoppen</string>
     <string name="settings">Einstellungen</string>
+    <string name="cd_step_minus">Zeit verringern</string>
+    <string name="cd_step_plus">Zeit erhöhen</string>
+
+    <!-- Time units shown under the dial -->
+    <string name="time_unit_minute">minute</string>
+    <string name="time_unit_minutes">minuten</string>
+    <string name="time_unit_hour">stunde</string>
+    <string name="time_unit_hours">stunden</string>
+    <string name="time_unit_hr_min">std · min</string>
 
     <!-- Settings Screen -->
     <string name="settings_title">Einstellungen</string>
@@ -25,4 +33,11 @@
     <string name="category_haptic">Haptisches Feedback</string>
     <string name="haptic_title">Haptisches Feedback</string>
     <string name="haptic_description">Vibrieren bei Verwendung von Timer und Bedienelementen</string>
+
+    <!-- Theme names -->
+    <string name="theme_midnight">Mitternacht</string>
+    <string name="theme_ocean">Ozean</string>
+    <string name="theme_ember">Glut</string>
+    <string name="theme_light">Hell</string>
+    <string name="theme_basic">Einfach</string>
 </resources>

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SleepTimer</string>
-    <string name="minutes_label">MINUTES</string>
     <string name="start_timer">Start timer</string>
     <string name="stop_timer">Stop timer</string>
     <string name="settings">Settings</string>
+    <string name="cd_step_minus">Decrease time</string>
+    <string name="cd_step_plus">Increase time</string>
+
+    <!-- Time units shown under the dial -->
+    <string name="time_unit_minute">minute</string>
+    <string name="time_unit_minutes">minutes</string>
+    <string name="time_unit_hour">hour</string>
+    <string name="time_unit_hours">hours</string>
+    <string name="time_unit_hr_min">hr · min</string>
 
     <!-- Settings Screen -->
     <string name="settings_title">Settings</string>
@@ -25,4 +33,11 @@
     <string name="category_haptic">Haptic Feedback</string>
     <string name="haptic_title">Haptic feedback</string>
     <string name="haptic_description">Vibrate when using timer and controls</string>
+
+    <!-- Theme names -->
+    <string name="theme_midnight">Midnight</string>
+    <string name="theme_ocean">Ocean</string>
+    <string name="theme_ember">Ember</string>
+    <string name="theme_light">Light</string>
+    <string name="theme_basic">Basic</string>
 </resources>


### PR DESCRIPTION
## Summary
- Replace hardcoded English strings in `TimeDisplay` (minute/minutes/hour/hours/hr · min) with string resources — this is what actually rendered as `MINUTES` in the UI; the existing `minutes_label` resource was never referenced.
- Localize `+`/`-` button `contentDescription`s (previously hardcoded `"Minus"`/`"Plus"`).
- Convert `AppTheme.label: String` to `@StringRes labelRes: Int` and translate theme names (Midnight/Ocean/Ember/Light/Basic → Mitternacht/Ozean/Glut/Hell/Einfach).
- Remove unused `minutes_label` entries from both `app/` and `feature/timer/` string resources.

## Test plan
- [ ] Launch app with system locale set to English — time unit under the dial reads `MINUTES` / `HOURS` / `HR · MIN`, theme cards read Midnight/Ocean/Ember/Light/Basic.
- [ ] Launch with system locale set to German — time unit reads `MINUTEN` / `STUNDEN` / `STD · MIN`, theme cards read Mitternacht/Ozean/Glut/Hell/Einfach.
- [ ] TalkBack reads localized labels for the +/- step buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)