### PR TITLE
fix(notification,service): plural minutes, distinct fade-out text, and interactive fade-out

### DIFF
--- a/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/SleepTimerService.kt
+++ b/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/SleepTimerService.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -57,6 +58,7 @@ class SleepTimerService : Service() {
         const val ACTION_ADD_MINUTES = "dev.xitee.sleeptimer.action.ADD_MINUTES"
         const val ACTION_SUBTRACT_MINUTES = "dev.xitee.sleeptimer.action.SUBTRACT_MINUTES"
         const val EXTRA_DURATION_MILLIS = "dev.xitee.sleeptimer.extra.DURATION_MILLIS"
+        private const val FADE_IN_SECONDS = 2
     }
 
     override fun onCreate() {
@@ -122,103 +124,130 @@ class SleepTimerService : Service() {
         // Update repository
         updateTimerState(TimerPhase.RUNNING)
 
-        // Start countdown
+        // Start countdown. onTimerExpired runs inside this job so that cancelling
+        // the job also cancels the fade-out — lets + and Cancel interrupt the fade.
         countdownJob = serviceScope.launch {
-            while (remainingMillis > 0) {
-                delay(1000L)
-                remainingMillis -= 1000L
-
-                if (remainingMillis <= 0) {
-                    remainingMillis = 0
-                }
-
-                updateTimerState(TimerPhase.RUNNING)
-
-                val remainingMinutes = remainingMillisToDisplayMinutes(remainingMillis)
-                notificationManager.updateNotification(remainingMinutes, stepMinutes)
-            }
-
-            // Timer expired — handle completion
-            onTimerExpired()
+            runCountdownAndExpire()
         }
     }
 
-    private fun addStep() {
-        if (countdownJob?.isActive == true) {
-            val stepMillis = stepMinutes * 60 * 1000L
-            remainingMillis += stepMillis
-            totalDurationMillis += stepMillis
+    private suspend fun runCountdownAndExpire() {
+        while (remainingMillis > 0) {
+            delay(1000L)
+            remainingMillis -= 1000L
+
+            if (remainingMillis <= 0) {
+                remainingMillis = 0
+            }
+
             updateTimerState(TimerPhase.RUNNING)
-            notificationManager.updateNotification(
-                remainingMillisToDisplayMinutes(remainingMillis),
-                stepMinutes,
-            )
+
+            val remainingMinutes = remainingMillisToDisplayMinutes(remainingMillis)
+            notificationManager.updateNotification(remainingMinutes, stepMinutes)
+        }
+
+        onTimerExpired()
+    }
+
+    private fun addStep() {
+        when (timerRepository.timerState.value.phase) {
+            TimerPhase.RUNNING -> {
+                if (countdownJob?.isActive != true) return
+                val stepMillis = stepMinutes * 60 * 1000L
+                remainingMillis += stepMillis
+                totalDurationMillis += stepMillis
+                updateTimerState(TimerPhase.RUNNING)
+                notificationManager.updateNotification(
+                    remainingMillisToDisplayMinutes(remainingMillis),
+                    stepMinutes,
+                )
+            }
+            TimerPhase.FADING_OUT -> {
+                // Replace countdownJob with the fade-in + restart so Cancel during
+                // the 2 s fade-in window cancels this whole sequence, not just the
+                // already-finished fade-out.
+                val oldJob = countdownJob ?: return
+                val stepMillis = stepMinutes * 60 * 1000L
+                countdownJob = serviceScope.launch {
+                    oldJob.cancelAndJoin()
+                    mediaVolumeController.fadeInToOriginal(FADE_IN_SECONDS)
+                    totalDurationMillis = stepMillis
+                    remainingMillis = stepMillis
+                    updateTimerState(TimerPhase.RUNNING)
+                    notificationManager.updateNotification(
+                        remainingMillisToDisplayMinutes(remainingMillis),
+                        stepMinutes,
+                    )
+                    runCountdownAndExpire()
+                }
+            }
+            else -> {}
         }
     }
 
     private fun subtractStep() {
-        if (countdownJob?.isActive == true) {
-            val stepMillis = stepMinutes * 60 * 1000L
-            if (remainingMillis <= stepMillis) return
-            remainingMillis -= stepMillis
-            totalDurationMillis = (totalDurationMillis - stepMillis).coerceAtLeast(remainingMillis)
-            updateTimerState(TimerPhase.RUNNING)
-            notificationManager.updateNotification(
-                remainingMillisToDisplayMinutes(remainingMillis),
-                stepMinutes,
-            )
-        }
+        if (timerRepository.timerState.value.phase != TimerPhase.RUNNING) return
+        if (countdownJob?.isActive != true) return
+        val stepMillis = stepMinutes * 60 * 1000L
+        if (remainingMillis <= stepMillis) return
+        remainingMillis -= stepMillis
+        totalDurationMillis = (totalDurationMillis - stepMillis).coerceAtLeast(remainingMillis)
+        updateTimerState(TimerPhase.RUNNING)
+        notificationManager.updateNotification(
+            remainingMillisToDisplayMinutes(remainingMillis),
+            stepMinutes,
+        )
     }
 
     private fun cancelTimer() {
-        countdownJob?.cancel()
+        val job = countdownJob
         countdownJob = null
-
-        // Restore volume if fading was in progress
-        mediaVolumeController.restoreVolume()
-
-        updateTimerState(TimerPhase.IDLE)
-        notificationManager.cancelNotification()
-        stopForeground(STOP_FOREGROUND_REMOVE)
-        stopSelf()
-    }
-
-    private fun onTimerExpired() {
         serviceScope.launch {
-            val settings: UserSettings = settingsRepository.settings.first()
-
-            if (settings.stopMediaPlayback) {
-                updateTimerState(TimerPhase.FADING_OUT)
-                notificationManager.updateNotification(0, stepMinutes, TimerPhase.FADING_OUT)
-                mediaVolumeController.fadeOutAndPause(settings.fadeOutDurationSeconds)
-            }
-
-            if (settings.turnOffWifi && shizukuManager.isReady()) {
-                shizukuWifiController.disableWifi()
-            }
-
-            if (settings.turnOffBluetooth && shizukuManager.isReady()) {
-                shizukuBluetoothController.disableBluetooth()
-            }
-
-            if (settings.screenOff) {
-                val usedShizuku = if (settings.softScreenOff && shizukuManager.isReady()) {
-                    shizukuScreenOffHelper.turnOffScreen()
-                } else {
-                    false
-                }
-                if (!usedShizuku) {
-                    // Hard-lock fallback: also the path when softScreenOff is off, or
-                    // when the Shizuku attempt failed. Forces credential on next unlock.
-                    screenLockHelper.lockScreen()
-                }
-            }
-
-            // Reset state before stopping foreground to avoid race with onDestroy
-            timerRepository.updateState(TimerState())
+            // Join the fade-out before restoring volume, otherwise the still-running
+            // fade coroutine would overwrite the restored volume at its next step.
+            job?.cancelAndJoin()
+            mediaVolumeController.restoreVolume()
+            updateTimerState(TimerPhase.IDLE)
+            notificationManager.cancelNotification()
             stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
         }
+    }
+
+    private suspend fun onTimerExpired() {
+        val settings: UserSettings = settingsRepository.settings.first()
+
+        if (settings.stopMediaPlayback) {
+            updateTimerState(TimerPhase.FADING_OUT)
+            notificationManager.updateNotification(0, stepMinutes, TimerPhase.FADING_OUT)
+            mediaVolumeController.fadeOutAndPause(settings.fadeOutDurationSeconds)
+        }
+
+        if (settings.turnOffWifi && shizukuManager.isReady()) {
+            shizukuWifiController.disableWifi()
+        }
+
+        if (settings.turnOffBluetooth && shizukuManager.isReady()) {
+            shizukuBluetoothController.disableBluetooth()
+        }
+
+        if (settings.screenOff) {
+            val usedShizuku = if (settings.softScreenOff && shizukuManager.isReady()) {
+                shizukuScreenOffHelper.turnOffScreen()
+            } else {
+                false
+            }
+            if (!usedShizuku) {
+                // Hard-lock fallback: also the path when softScreenOff is off, or
+                // when the Shizuku attempt failed. Forces credential on next unlock.
+                screenLockHelper.lockScreen()
+            }
+        }
+
+        // Reset state before stopping foreground to avoid race with onDestroy
+        timerRepository.updateState(TimerState())
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
     }
 
     private fun updateTimerState(phase: TimerPhase) {

--- a/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/SleepTimerService.kt
+++ b/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/SleepTimerService.kt
@@ -165,12 +165,13 @@ class SleepTimerService : Service() {
             TimerPhase.FADING_OUT -> {
                 // Replace countdownJob with the fade-in + restart so Cancel during
                 // the 2 s fade-in window cancels this whole sequence, not just the
-                // already-finished fade-out.
+                // already-finished fade-out. The countdown and fade-in run in
+                // parallel — the clock ticks from the moment the user presses +,
+                // not after the fade-in completes.
                 val oldJob = countdownJob ?: return
                 val stepMillis = stepMinutes * 60 * 1000L
                 countdownJob = serviceScope.launch {
                     oldJob.cancelAndJoin()
-                    mediaVolumeController.fadeInToOriginal(FADE_IN_SECONDS)
                     totalDurationMillis = stepMillis
                     remainingMillis = stepMillis
                     updateTimerState(TimerPhase.RUNNING)
@@ -178,6 +179,7 @@ class SleepTimerService : Service() {
                         remainingMillisToDisplayMinutes(remainingMillis),
                         stepMinutes,
                     )
+                    launch { mediaVolumeController.fadeInToOriginal(FADE_IN_SECONDS) }
                     runCountdownAndExpire()
                 }
             }

--- a/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/SleepTimerService.kt
+++ b/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/SleepTimerService.kt
@@ -189,7 +189,7 @@ class SleepTimerService : Service() {
 
             if (settings.stopMediaPlayback) {
                 updateTimerState(TimerPhase.FADING_OUT)
-                notificationManager.updateNotification(0, stepMinutes)
+                notificationManager.updateNotification(0, stepMinutes, TimerPhase.FADING_OUT)
                 mediaVolumeController.fadeOutAndPause(settings.fadeOutDurationSeconds)
             }
 

--- a/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/media/MediaVolumeController.kt
+++ b/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/media/MediaVolumeController.kt
@@ -35,6 +35,24 @@ class MediaVolumeController @Inject constructor(
         restoreVolume()
     }
 
+    suspend fun fadeInToOriginal(durationSeconds: Int) {
+        val target = originalVolume
+        if (target < 0) return
+        val current = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
+        if (current >= target || durationSeconds <= 0) {
+            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, target, 0)
+            originalVolume = -1
+            return
+        }
+        val steps = target - current
+        val intervalMs = (durationSeconds * 1000L) / steps
+        for (i in current + 1..target) {
+            audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, i, 0)
+            delay(intervalMs)
+        }
+        originalVolume = -1
+    }
+
     fun pauseMedia() {
         val downEvent = KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MEDIA_PAUSE)
         val upEvent = KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MEDIA_PAUSE)

--- a/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/notification/TimerNotificationManager.kt
+++ b/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/notification/TimerNotificationManager.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.xitee.sleeptimer.core.data.model.TimerPhase
 import dev.xitee.sleeptimer.core.service.R
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -45,11 +46,19 @@ class TimerNotificationManager @Inject constructor(
         notificationManager.createNotificationChannel(channel)
     }
 
-    fun buildNotification(remainingMinutes: Int, stepMinutes: Int): Notification {
-        val contentText = if (remainingMinutes > 0) {
-            context.getString(R.string.notification_minutes_remaining, remainingMinutes)
-        } else {
-            context.getString(R.string.notification_less_than_minute)
+    fun buildNotification(
+        remainingMinutes: Int,
+        stepMinutes: Int,
+        phase: TimerPhase = TimerPhase.RUNNING,
+    ): Notification {
+        val contentText = when {
+            phase == TimerPhase.FADING_OUT -> context.getString(R.string.notification_fading_out)
+            remainingMinutes > 0 -> context.resources.getQuantityString(
+                R.plurals.notification_minutes_remaining,
+                remainingMinutes,
+                remainingMinutes,
+            )
+            else -> context.getString(R.string.notification_less_than_minute)
         }
 
         // Content intent to open the app
@@ -105,8 +114,15 @@ class TimerNotificationManager @Inject constructor(
         )
     }
 
-    fun updateNotification(remainingMinutes: Int, stepMinutes: Int) {
-        notificationManager.notify(NOTIFICATION_ID, buildNotification(remainingMinutes, stepMinutes))
+    fun updateNotification(
+        remainingMinutes: Int,
+        stepMinutes: Int,
+        phase: TimerPhase = TimerPhase.RUNNING,
+    ) {
+        notificationManager.notify(
+            NOTIFICATION_ID,
+            buildNotification(remainingMinutes, stepMinutes, phase),
+        )
     }
 
     fun cancelNotification() {

--- a/core/service/src/main/res/values-de/strings.xml
+++ b/core/service/src/main/res/values-de/strings.xml
@@ -3,8 +3,12 @@
     <string name="notification_channel_name">Schlaf-Timer</string>
     <string name="notification_channel_description">Zeigt verbleibende Zeit des Schlaf-Timers</string>
     <string name="notification_content_title">Schlaf-Timer</string>
-    <string name="notification_minutes_remaining">Noch %d Minuten</string>
+    <plurals name="notification_minutes_remaining">
+        <item quantity="one">Noch %d Minute</item>
+        <item quantity="other">Noch %d Minuten</item>
+    </plurals>
     <string name="notification_less_than_minute">Weniger als eine Minute verbleibend</string>
+    <string name="notification_fading_out">Wiedergabe wird ausgeblendet</string>
     <string name="notification_action_add_minutes">+%d Min</string>
     <string name="notification_action_subtract_minutes">-%d Min</string>
     <string name="notification_action_cancel">Abbrechen</string>

--- a/core/service/src/main/res/values/strings.xml
+++ b/core/service/src/main/res/values/strings.xml
@@ -3,8 +3,12 @@
     <string name="notification_channel_name">Sleep Timer</string>
     <string name="notification_channel_description">Shows remaining time for sleep timer</string>
     <string name="notification_content_title">Sleep Timer</string>
-    <string name="notification_minutes_remaining">%d minutes remaining</string>
+    <plurals name="notification_minutes_remaining">
+        <item quantity="one">%d minute remaining</item>
+        <item quantity="other">%d minutes remaining</item>
+    </plurals>
     <string name="notification_less_than_minute">Less than a minute remaining</string>
+    <string name="notification_fading_out">Fading out playback</string>
     <string name="notification_action_add_minutes">+%d min</string>
     <string name="notification_action_subtract_minutes">-%d min</string>
     <string name="notification_action_cancel">Cancel</string>


### PR DESCRIPTION
Two related changes to the fade-out phase of the sleep timer.

## 1. Notification text
- `notification_minutes_remaining` was a single `%d` string, so "Noch 1 Minuten" / "1 minutes remaining" showed up. Now an Android `<plurals>` resource (EN + DE).
- During fade-out the notification kept saying "Weniger als eine Minute verbleibend", which read as the timer still running for another minute. It now shows a dedicated "Wiedergabe wird ausgeblendet" / "Fading out playback" message. `TimerNotificationManager.buildNotification` gained an optional `TimerPhase`.

## 2. `+` and Cancel during fade-out
Previously `+` was a no-op during fade-out, and Cancel raced against the still-running fade coroutine when it restored the volume. Now:

| Action | RUNNING | FADING_OUT |
|---|---|---|
| `+` | unchanged (add step minutes) | cancel fade → 2 s fade-in → fresh countdown with step minutes |
| `-` | unchanged | no-op |
| Cancel | unchanged | `cancelAndJoin` fade → snap volume back → stop service (race fixed) |

Implementation:
- `onTimerExpired` is now `suspend` and runs inside `countdownJob` — cancelling the job cancels the fade.
- `MediaVolumeController.fadeInToOriginal(durationSeconds)` added.
- `addStep`'s FADING_OUT branch replaces `countdownJob` with a coroutine that awaits the fade cancel, fades back in, and runs the new countdown, so Cancel pressed during the 2 s fade-in window still cancels the whole sequence.
- Countdown loop extracted into `runCountdownAndExpire()` to share it between the fresh-start and fade-in-restart paths.

## Test plan
- [ ] 1-min timer, DE locale → "Noch 1 Minute" (not "Minuten")
- [ ] 2-min timer → "Noch 2 Minuten"
- [ ] Let fade-out start → notification reads "Wiedergabe wird ausgeblendet"
- [ ] Press `+` during fade-out → volume fades back up over ~2 s, countdown restarts with step minutes
- [ ] Press Cancel during fade-out → volume snaps to original, service stops cleanly
- [ ] Press Cancel during the 2 s fade-in after a `+` → service stops cleanly, no ghost timer
- [ ] Press `-` during fade-out → nothing happens
- [ ] Press `+` twice in quick succession during fade-out → single restart (second press ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)