### PR TITLE
feat(about): add About screen

### DIFF
--- a/app/src/main/kotlin/dev/xitee/sleeptimer/navigation/Routes.kt
+++ b/app/src/main/kotlin/dev/xitee/sleeptimer/navigation/Routes.kt
@@ -7,3 +7,6 @@ data object TimerRoute
 
 @Serializable
 data object SettingsRoute
+
+@Serializable
+data object AboutRoute

--- a/app/src/main/kotlin/dev/xitee/sleeptimer/navigation/SleepTimerNavHost.kt
+++ b/app/src/main/kotlin/dev/xitee/sleeptimer/navigation/SleepTimerNavHost.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import dev.xitee.sleeptimer.feature.timer.about.AboutScreen
 import dev.xitee.sleeptimer.feature.timer.settings.SettingsScreen
 import dev.xitee.sleeptimer.feature.timer.timer.TimerScreen
 
@@ -22,6 +23,12 @@ fun SleepTimerNavHost() {
         }
         composable<SettingsRoute> {
             SettingsScreen(
+                onBack = { navController.popBackStack() },
+                onNavigateToAbout = { navController.navigate(AboutRoute) },
+            )
+        }
+        composable<AboutRoute> {
+            AboutScreen(
                 onBack = { navController.popBackStack() },
             )
         }

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/about/AboutScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/about/AboutScreen.kt
@@ -1,0 +1,247 @@
+package dev.xitee.sleeptimer.feature.timer.about
+
+import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.core.net.toUri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.background
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.xitee.sleeptimer.feature.timer.R
+import dev.xitee.sleeptimer.feature.timer.theme.AppThemes
+import dev.xitee.sleeptimer.feature.timer.theme.LocalAppTheme
+import dev.xitee.sleeptimer.feature.timer.theme.appTheme
+import dev.xitee.sleeptimer.feature.timer.timer.components.TimerBackground
+
+private const val REPO_URL = "https://github.com/Xitee1/sleep-timer"
+private const val DONATE_URL = "https://github.com/Xitee1/Xitee1/blob/main/donate.md"
+
+@Composable
+fun AboutScreen(
+    onBack: () -> Unit,
+    viewModel: AboutViewModel = hiltViewModel(),
+) {
+    val settings by viewModel.settings.collectAsStateWithLifecycle()
+
+    CompositionLocalProvider(LocalAppTheme provides AppThemes.byId(settings.theme)) {
+        AboutContent(
+            starsEnabled = settings.starsEnabled,
+            onBack = onBack,
+        )
+    }
+}
+
+@Composable
+private fun AboutContent(
+    starsEnabled: Boolean,
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    val versionName = remember {
+        try {
+            context.packageManager.getPackageInfo(context.packageName, 0).versionName.orEmpty()
+        } catch (_: PackageManager.NameNotFoundException) {
+            ""
+        }
+    }
+
+    val openUrl: (String) -> Unit = { url ->
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        runCatching { context.startActivity(intent) }
+    }
+
+    TimerBackground(
+        animating = false,
+        starsEnabled = starsEnabled,
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .windowInsetsPadding(WindowInsets.systemBars),
+        ) {
+            AboutTopBar(onBack = onBack)
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                SectionHeader(stringResource(R.string.category_about))
+
+                AboutRow(
+                    icon = Icons.Default.Info,
+                    title = stringResource(R.string.about_version_title),
+                    value = versionName,
+                )
+                AboutRow(
+                    icon = Icons.Default.Person,
+                    title = stringResource(R.string.about_author_title),
+                    value = stringResource(R.string.about_author_value),
+                )
+                AboutRow(
+                    icon = Icons.Default.Code,
+                    title = stringResource(R.string.about_repo_title),
+                    value = stringResource(R.string.about_repo_value),
+                    onClick = { openUrl(REPO_URL) },
+                )
+                AboutRow(
+                    icon = Icons.Default.FavoriteBorder,
+                    title = stringResource(R.string.about_donate_title),
+                    value = stringResource(R.string.about_donate_description),
+                    onClick = { openUrl(DONATE_URL) },
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun AboutTopBar(onBack: () -> Unit) {
+    val theme = appTheme()
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .padding(horizontal = 8.dp),
+    ) {
+        IconButton(
+            onClick = onBack,
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .size(44.dp),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = null,
+                tint = theme.textPrimary,
+            )
+        }
+        Text(
+            text = stringResource(R.string.about_title),
+            style = MaterialTheme.typography.titleLarge,
+            color = theme.textPrimary,
+            modifier = Modifier.align(Alignment.Center),
+        )
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    val theme = appTheme()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 24.dp, end = 24.dp, top = 20.dp, bottom = 8.dp),
+        horizontalArrangement = Arrangement.Start,
+    ) {
+        Text(
+            text = text.uppercase(),
+            style = MaterialTheme.typography.labelLarge,
+            color = theme.textMuted,
+        )
+    }
+}
+
+@Composable
+private fun AboutRow(
+    icon: ImageVector,
+    title: String,
+    value: String?,
+    onClick: (() -> Unit)? = null,
+) {
+    val theme = appTheme()
+    val rowModifier = Modifier
+        .fillMaxWidth()
+        .let { if (onClick != null) it.clickable { onClick() } else it }
+        .padding(horizontal = 20.dp, vertical = 14.dp)
+
+    Row(
+        modifier = rowModifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(theme.surface1),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = theme.accent,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        Spacer(modifier = Modifier.width(14.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = theme.textPrimary,
+            )
+            if (!value.isNullOrEmpty()) {
+                Spacer(modifier = Modifier.height(3.dp))
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.bodyMedium.copy(lineHeight = 20.sp),
+                    color = theme.textDim,
+                )
+            }
+        }
+        if (onClick != null) {
+            Spacer(modifier = Modifier.width(16.dp))
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                contentDescription = null,
+                tint = theme.textMuted,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+    }
+}
+

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/about/AboutViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/about/AboutViewModel.kt
@@ -1,0 +1,20 @@
+package dev.xitee.sleeptimer.feature.timer.about
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.xitee.sleeptimer.core.data.model.UserSettings
+import dev.xitee.sleeptimer.core.data.repository.SettingsRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class AboutViewModel @Inject constructor(
+    settingsRepository: SettingsRepository,
+) : ViewModel() {
+
+    val settings: StateFlow<UserSettings> = settingsRepository.settings
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), UserSettings())
+}

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsScreen.kt
@@ -5,6 +5,8 @@ import android.app.admin.DevicePolicyManager
 import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,17 +19,22 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Bluetooth
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.MusicOff
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -62,6 +69,7 @@ import dev.xitee.sleeptimer.feature.timer.timer.components.TimerBackground
 @Composable
 fun SettingsScreen(
     onBack: () -> Unit,
+    onNavigateToAbout: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -71,6 +79,7 @@ fun SettingsScreen(
         SettingsContent(
             uiState = ready,
             onBack = onBack,
+            onNavigateToAbout = onNavigateToAbout,
             viewModel = viewModel,
         )
     }
@@ -80,6 +89,7 @@ fun SettingsScreen(
 private fun SettingsContent(
     uiState: SettingsUiState,
     onBack: () -> Unit,
+    onNavigateToAbout: () -> Unit,
     viewModel: SettingsViewModel,
 ) {
     val context = LocalContext.current
@@ -276,8 +286,61 @@ private fun SettingsContent(
                     onCheckedChange = { viewModel.updateHapticFeedback(it) },
                 )
 
+                SectionHeader(stringResource(R.string.category_about))
+                SettingsNavigationRow(
+                    icon = Icons.Default.Info,
+                    title = stringResource(R.string.about_entry_title),
+                    description = stringResource(R.string.about_entry_description),
+                    onClick = onNavigateToAbout,
+                )
+
                 Spacer(modifier = Modifier.height(32.dp))
             }
+        }
+    }
+}
+
+@Composable
+private fun SettingsNavigationRow(
+    icon: ImageVector,
+    title: String,
+    description: String,
+    onClick: () -> Unit,
+) {
+    val theme = appTheme()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(theme.surface1),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = theme.accent,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        Spacer(modifier = Modifier.width(14.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = theme.textPrimary,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = theme.textDim,
+            )
         }
     }
 }

--- a/feature/timer/src/main/res/values-de/strings.xml
+++ b/feature/timer/src/main/res/values-de/strings.xml
@@ -72,4 +72,17 @@
     <string name="screen_method_soft_description">Simuliert Power-Taste. Biometrische Entsperrung bleibt aktiv.</string>
     <string name="screen_method_active_hard">Geräteadministrator — Code zum Entsperren nötig</string>
     <string name="screen_method_active_soft">Shizuku — biometrische Entsperrung bleibt aktiv</string>
+
+    <!-- Über die App -->
+    <string name="category_about">Über</string>
+    <string name="about_title">Über</string>
+    <string name="about_entry_title">Über diese App</string>
+    <string name="about_entry_description">Version, Quellcode und Unterstützung</string>
+    <string name="about_version_title">Version</string>
+    <string name="about_author_title">Autor</string>
+    <string name="about_author_value">Xitee</string>
+    <string name="about_repo_title">Quellcode</string>
+    <string name="about_repo_value">github.com/Xitee1/sleep-timer</string>
+    <string name="about_donate_title">Spenden</string>
+    <string name="about_donate_description">Wenn dir diese App gefällt und du mich unterstützen möchtest, kannst du das hier tun.</string>
 </resources>

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -72,4 +72,17 @@
     <string name="screen_method_soft_description">Simulates power button. Biometric unlock stays active.</string>
     <string name="screen_method_active_hard">Device admin — credential required to unlock</string>
     <string name="screen_method_active_soft">Shizuku — biometric unlock stays active</string>
+
+    <!-- About -->
+    <string name="category_about">About</string>
+    <string name="about_title">About</string>
+    <string name="about_entry_title">About this app</string>
+    <string name="about_entry_description">Version, source code and support</string>
+    <string name="about_version_title">Version</string>
+    <string name="about_author_title">Author</string>
+    <string name="about_author_value">Xitee</string>
+    <string name="about_repo_title">Source code</string>
+    <string name="about_repo_value">github.com/Xitee1/sleep-timer</string>
+    <string name="about_donate_title">Donate</string>
+    <string name="about_donate_description">If this app is helpful and you\'d like to support me, you can do so here.</string>
 </resources>


### PR DESCRIPTION
## Summary
- New **About** screen showing version (read from `PackageManager`), author, source-code link and a donate link
- Reached through a new "About this app" row in Settings
- Strings provided in English and German

The donation entry uses the same icon + title + description row as the other entries; the explanatory text sits in the row's description slot so it's available without feeling intrusive.

## Test plan
- [ ] Open Settings → "About this app" opens the new screen
- [ ] Version row shows `1.0.0`
- [ ] Source code row opens GitHub repo in the browser
- [ ] Donate row opens the donation page in the browser
- [ ] Back arrow returns to Settings
- [ ] Theme is respected (Midnight / Ocean / Ember / Light / Basic)
- [ ] German locale shows translated strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)