### PR TITLE
fix(timer): enforce 1 minute minimum

### DIFF
--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -184,7 +184,7 @@ private fun TimerContent(
                 isMinusEnabled = if (isRunning) {
                     runningRemainingSeconds > settings.stepMinutes * 60
                 } else {
-                    dialState.totalMinutes > 0
+                    dialState.totalMinutes > 1
                 },
                 isPlusEnabled = !isRunning && dialState.totalMinutes < 300,
                 plusStepVisibleWhileRunning = true,

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerViewModel.kt
@@ -55,7 +55,7 @@ class TimerViewModel @Inject constructor(
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TimerUiState.Idle())
 
     fun setMinutes(minutes: Int) {
-        _selectedMinutes.value = minutes.coerceIn(0, 300)
+        _selectedMinutes.value = minutes.coerceIn(1, 300)
     }
 
     fun startTimer() {

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/components/CircularDialState.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/components/CircularDialState.kt
@@ -24,7 +24,9 @@ class CircularDialState {
     private var cumulativeDegrees = 0f
 
     val maxRevolutions = 5 // 5 hours
+    private val minMinutes = 1
     private val maxMinutes = maxRevolutions * 60
+    private val minDegrees = (minMinutes / 60f) * 360f
     private val maxDegrees = maxRevolutions * 360f
 
     init {
@@ -37,7 +39,7 @@ class CircularDialState {
     fun onDragStart(centerX: Float, centerY: Float, x: Float, y: Float) {
         isDragging = true
         previousAngle = computeAngle(centerX, centerY, x, y)
-        cumulativeDegrees = (revolutions * 360f + angleDegrees).coerceIn(0f, maxDegrees)
+        cumulativeDegrees = (revolutions * 360f + angleDegrees).coerceIn(minDegrees, maxDegrees)
     }
 
     fun onDrag(centerX: Float, centerY: Float, x: Float, y: Float) {
@@ -48,12 +50,12 @@ class CircularDialState {
         if (delta > 180f) delta -= 360f
         else if (delta < -180f) delta += 360f
 
-        cumulativeDegrees = (cumulativeDegrees + delta).coerceIn(0f, maxDegrees)
+        cumulativeDegrees = (cumulativeDegrees + delta).coerceIn(minDegrees, maxDegrees)
         previousAngle = newAngle
 
         revolutions = (cumulativeDegrees / 360f).toInt().coerceAtMost(maxRevolutions)
         angleDegrees = cumulativeDegrees - revolutions * 360f
-        totalMinutes = ((cumulativeDegrees / 360f) * 60f).roundToInt().coerceIn(0, maxMinutes)
+        totalMinutes = ((cumulativeDegrees / 360f) * 60f).roundToInt().coerceIn(minMinutes, maxMinutes)
     }
 
     fun onDragEnd() {
@@ -62,7 +64,7 @@ class CircularDialState {
     }
 
     fun setMinutes(minutes: Int) {
-        val clamped = minutes.coerceIn(0, maxMinutes)
+        val clamped = minutes.coerceIn(minMinutes, maxMinutes)
         totalMinutes = clamped
         cumulativeDegrees = (clamped / 60f) * 360f
         revolutions = clamped / 60


### PR DESCRIPTION
## Summary
- Clamp the circular dial, viewmodel, and minus-step button to a 1 minute floor so the timer can no longer be set to 0.
- Disable the minus button at 1 minute instead of 0, keeping the dial visual in sync with the enforced minimum.

## Test plan
- [ ] Drag the dial all the way back — it should stop at 1 minute, not 0.
- [ ] Tap the minus button repeatedly — it should become disabled once the timer reaches 1 minute.
- [ ] Confirm the start button reliably starts a timer when set to 1 minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)