### PR TITLE
feat(dial): gradient ring with snake-tail wrap past 60 min

### DIFF
--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/components/CircularDial.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/components/CircularDial.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
@@ -169,13 +170,15 @@ fun CircularDial(
                 style = Stroke(width = strokeWidth, cap = StrokeCap.Round),
             )
 
-            if (ringFraction > 0f) {
+            if (displayMinutes > 0f) {
                 drawProgressArc(
                     center = center,
                     radius = radius,
                     strokeWidth = strokeWidth,
                     fraction = ringFraction,
-                    accent = theme.accent,
+                    overflowing = displayMinutes >= 60f,
+                    trailColor = theme.accent.copy(alpha = 0.32f),
+                    leadColor = theme.accent,
                 )
             }
 
@@ -217,30 +220,98 @@ private fun DrawScope.drawProgressArc(
     radius: Float,
     strokeWidth: Float,
     fraction: Float,
-    accent: Color,
+    overflowing: Boolean,
+    trailColor: Color,
+    leadColor: Color,
 ) {
     val topLeft = Offset(center.x - radius, center.y - radius)
     val arcSize = Size(radius * 2, radius * 2)
-    val sweep = 360f * fraction.coerceIn(0f, 1f)
+    val glowStrokeWidth = strokeWidth + 8.dp.toPx()
+    val radToDeg = 180f / Math.PI.toFloat()
+    val mainCapDeg = (strokeWidth * 0.5f) / radius * radToDeg
 
-    drawArc(
-        color = accent.copy(alpha = 0.35f),
-        startAngle = -90f,
-        sweepAngle = sweep,
-        useCenter = false,
-        topLeft = topLeft,
-        size = arcSize,
-        style = Stroke(width = strokeWidth + 8.dp.toPx(), cap = StrokeCap.Round),
-    )
-    drawArc(
-        color = accent,
-        startAngle = -90f,
-        sweepAngle = sweep,
-        useCenter = false,
-        topLeft = topLeft,
-        size = arcSize,
-        style = Stroke(width = strokeWidth, cap = StrokeCap.Round),
-    )
+    val sweep = if (overflowing) 360f else 360f * fraction.coerceIn(0f, 1f)
+    // Rotate the canvas so that the sweep gradient's 0° axis (east in the rotated frame)
+    // aligns with the arc's start angle in the original frame — top when partial, handle
+    // position when the ring has wrapped past 60 minutes.
+    val rotationDegrees = if (overflowing) -90f + fraction * 360f else -90f
+    val leadStop = if (overflowing) 1f else sweep / 360f
+
+    // Main arc: inset by one cap on each side so the round caps land flush with the visible
+    // span — starts exactly at top, ends exactly at handle.
+    val mainStartOffset = if (overflowing) 0f else mainCapDeg
+    val mainSweep = if (overflowing) 360f else (sweep - 2f * mainCapDeg).coerceAtLeast(0f)
+
+    // The sweep gradient's stops determine color at every angle around the full circle,
+    // including outside the arc's visible range. Without a snap-back, round caps extending
+    // past the last stop sample the lead color (Android clamps to last stop), which paints
+    // a bright blob where we expect a faded halo. Adding a quick trail-colored stop just
+    // past `leadStop` keeps the glow's rounded extension soft.
+    val snapStop = (leadStop + 0.001f).coerceAtMost(0.999f)
+    val trailFaded = trailColor.copy(alpha = trailColor.alpha * 0.5f)
+    val leadFaded = leadColor.copy(alpha = leadColor.alpha * 0.35f)
+
+    val mainBrush = if (overflowing) {
+        Brush.sweepGradient(
+            0f to trailColor,
+            1f to leadColor,
+            center = center,
+        )
+    } else {
+        Brush.sweepGradient(
+            0f to trailColor,
+            leadStop to leadColor,
+            snapStop to trailColor,
+            1f to trailColor,
+            center = center,
+        )
+    }
+    val glowBrush = if (overflowing) {
+        Brush.sweepGradient(
+            0f to trailFaded,
+            1f to leadFaded,
+            center = center,
+        )
+    } else {
+        Brush.sweepGradient(
+            0f to trailFaded,
+            leadStop to leadFaded,
+            snapStop to trailFaded,
+            1f to trailFaded,
+            center = center,
+        )
+    }
+
+    // Glow shares the main arc's geometric start/sweep — only the stroke is wider. The
+    // round cap then overhangs each end by the same radial amount it overhangs the sides,
+    // so the shadow halo reads as uniform thickness all the way around.
+    val glowStartOffset = mainStartOffset
+    val glowSweep = mainSweep
+
+    rotate(degrees = rotationDegrees, pivot = center) {
+        if (glowSweep > 0f) {
+            drawArc(
+                brush = glowBrush,
+                startAngle = glowStartOffset,
+                sweepAngle = glowSweep,
+                useCenter = false,
+                topLeft = topLeft,
+                size = arcSize,
+                style = Stroke(width = glowStrokeWidth, cap = StrokeCap.Round),
+            )
+        }
+        if (mainSweep > 0f) {
+            drawArc(
+                brush = mainBrush,
+                startAngle = mainStartOffset,
+                sweepAngle = mainSweep,
+                useCenter = false,
+                topLeft = topLeft,
+                size = arcSize,
+                style = Stroke(width = strokeWidth, cap = StrokeCap.Round),
+            )
+        }
+    }
 }
 
 private fun DrawScope.drawHourDots(center: Offset, radius: Float, hoursComplete: Int, theme: AppTheme) {


### PR DESCRIPTION
## Summary
- Paint the progress arc with a sweep gradient from a faded accent at the tail to the full accent at the handle.
- Once the timer exceeds 60 minutes the arc becomes a full 360° ring whose gradient rotates with the handle (snake-chases-its-tail effect).
- Glow shares the main arc's start and sweep — the wider stroke creates a uniform shadow halo around top, sides, and handle with the same overhang.

## Test plan
- [ ] Set the timer below 60 minutes and verify the partial arc starts at the top with faded trail color, fades to full accent at the handle.
- [ ] Cross the 60 minute mark and confirm the ring closes to 360° and the gradient rotates smoothly with the handle as minutes increase.
- [ ] Check each theme (Midnight, Ocean, Ember, Light, Basic) for the gradient rendering.
- [ ] Confirm there is no bright blob at the top or a bulge past the handle — halo should look uniform all the way around.
- [ ] Let a running timer count down and verify the visual stays consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)