### PR TITLE
feat(timer): show predicted end time under dial

### DIFF
--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -112,6 +114,22 @@ private fun TimerContent(
         ) {
             HomeTopBar(onOpenSettings = onNavigateToSettings)
 
+            val nowMillis by produceState(initialValue = System.currentTimeMillis()) {
+                while (true) {
+                    value = System.currentTimeMillis()
+                    kotlinx.coroutines.delay(10_000L)
+                }
+            }
+            val endMillis: Long? = when (val s = uiState) {
+                is TimerUiState.Idle ->
+                    if (s.selectedMinutes > 0) nowMillis + s.selectedMinutes * 60_000L else null
+                is TimerUiState.Running -> nowMillis + s.remainingMillis
+                is TimerUiState.FadingOut -> null
+            }
+            val timeFormatter = remember(context) {
+                android.text.format.DateFormat.getTimeFormat(context)
+            }
+
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -119,23 +137,53 @@ private fun TimerContent(
                     .padding(horizontal = 56.dp),
                 contentAlignment = Alignment.Center,
             ) {
-                CircularDial(
-                    state = dialState,
-                    isRunning = isRunning,
-                    runningMinutes = runningMinutes,
-                    hapticEnabled = settings.hapticFeedbackEnabled,
-                    onMinutesChanged = { viewModel.setMinutes(it) },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .sizeIn(maxWidth = 320.dp, maxHeight = 320.dp),
-                )
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularDial(
+                            state = dialState,
+                            isRunning = isRunning,
+                            runningMinutes = runningMinutes,
+                            hapticEnabled = settings.hapticFeedbackEnabled,
+                            onMinutesChanged = { viewModel.setMinutes(it) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .sizeIn(maxWidth = 320.dp, maxHeight = 320.dp),
+                        )
 
-                when (val s = uiState) {
-                    is TimerUiState.Idle -> TimeDisplay(totalMinutes = s.selectedMinutes)
-                    is TimerUiState.Running -> TimeDisplay(
-                        totalMinutes = remainingMillisToDisplayMinutes(s.remainingMillis),
-                    )
-                    is TimerUiState.FadingOut -> TimeDisplay(totalMinutes = 0)
+                        when (val s = uiState) {
+                            is TimerUiState.Idle -> TimeDisplay(totalMinutes = s.selectedMinutes)
+                            is TimerUiState.Running -> TimeDisplay(
+                                totalMinutes = remainingMillisToDisplayMinutes(s.remainingMillis),
+                            )
+                            is TimerUiState.FadingOut -> TimeDisplay(totalMinutes = 0)
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(24.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (endMillis != null) {
+                            Text(
+                                text = stringResource(
+                                    R.string.ends_at_time,
+                                    timeFormatter.format(java.util.Date(endMillis)),
+                                ),
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = appTheme().textDim,
+                            )
+                        }
+                    }
                 }
             }
 

--- a/feature/timer/src/main/res/values-de/strings.xml
+++ b/feature/timer/src/main/res/values-de/strings.xml
@@ -13,6 +13,7 @@
     <string name="time_unit_hour">stunde</string>
     <string name="time_unit_hours">stunden</string>
     <string name="time_unit_hr_min">std · min</string>
+    <string name="ends_at_time">Endet um %1$s</string>
 
     <!-- Settings Screen -->
     <string name="settings_title">Einstellungen</string>

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="time_unit_hour">hour</string>
     <string name="time_unit_hours">hours</string>
     <string name="time_unit_hr_min">hr · min</string>
+    <string name="ends_at_time">Ends at %1$s</string>
 
     <!-- Settings Screen -->
     <string name="settings_title">Settings</string>


### PR DESCRIPTION
## Summary
- Adds a small "Endet um HH:MM" / "Ends at HH:MM" line directly below the dial so it's obvious when the timer will fire.
- Honors the system 12/24-hour preference; ticks every 10s while idle so the value tracks the wall clock as the user lingers.
- Hidden when no timer is set (idle, 0 min) and during fade-out.

## Test plan
- [ ] Idle, set 30 min → end time updates as the wall clock advances
- [ ] Switch device to 12h format → label renders as e.g. "6:02 PM"
- [ ] Start timer → end time stays fixed (within tick granularity)
- [ ] Set timer to 0 min while idle → no end-time text shown
- [ ] German locale → reads "Endet um …"

🤖 Generated with [Claude Code](https://claude.com/claude-code)