### PR TITLE
chore(i18n-de): tighten settings labels

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -11,11 +11,11 @@
     <string name="settings_title">Einstellungen</string>
     <string name="category_sleep_timer">Sleep Timer</string>
     <string name="playback_title">Wiedergabe</string>
-    <string name="playback_description">Audio- und Videowiedergabe stoppen</string>
+    <string name="playback_description">Medienwiedergabe stoppen</string>
     <string name="fade_out_title">Fade-out-Dauer</string>
     <string name="fade_out_seconds">%d Sekunden</string>
     <string name="screen_title">Bildschirm</string>
-    <string name="screen_description">Bildschirm sperren wenn Timer endet (Shizuku optional)</string>
+    <string name="screen_description">Display ausschalten (Shizuku optional)</string>
     <string name="screen_admin_required">Geräteadministrator-Berechtigung erforderlich</string>
     <string name="category_haptic">Haptisches Feedback</string>
     <string name="haptic_title">Haptisches Feedback</string>

--- a/feature/timer/src/main/res/values-de/strings.xml
+++ b/feature/timer/src/main/res/values-de/strings.xml
@@ -22,13 +22,13 @@
     <string name="stars_unavailable">Für dieses Theme nicht verfügbar</string>
     <string name="category_sleep_timer">Sleep Timer</string>
     <string name="playback_title">Wiedergabe</string>
-    <string name="playback_description">Audio- und Videowiedergabe stoppen</string>
+    <string name="playback_description">Medienwiedergabe stoppen</string>
     <string name="fade_out_title">Fade-out-Dauer</string>
     <string name="fade_out_seconds">%d Sekunden</string>
     <string name="step_minutes_title">+/− Schrittweite</string>
     <string name="step_minutes_value">%d Min</string>
     <string name="screen_title">Bildschirm</string>
-    <string name="screen_description">Bildschirm sperren wenn Timer endet (Shizuku optional)</string>
+    <string name="screen_description">Display ausschalten (Shizuku optional)</string>
     <string name="screen_admin_required">Geräteadministrator-Berechtigung erforderlich</string>
     <string name="category_haptic">Haptisches Feedback</string>
     <string name="haptic_title">Haptisches Feedback</string>
@@ -61,9 +61,9 @@
 
     <!-- Shizuku-Funktionen -->
     <string name="wifi_off_title">WLAN ausschalten</string>
-    <string name="wifi_off_description">WLAN deaktivieren wenn Timer endet (benötigt Shizuku)</string>
+    <string name="wifi_off_description">WLAN deaktivieren (Shizuku benötigt)</string>
     <string name="bluetooth_off_title">Bluetooth ausschalten</string>
-    <string name="bluetooth_off_description">Bluetooth deaktivieren wenn Timer endet (benötigt Shizuku)</string>
+    <string name="bluetooth_off_description">Bluetooth deaktivieren (Shizuku benötigt)</string>
 
     <!-- Sperrmethoden-Dialog -->
     <string name="screen_method_dialog_title">Sperrmethode wählen</string>


### PR DESCRIPTION
## Summary
- Shorten German settings copy for playback, screen, Wi-Fi and Bluetooth rows
- `playback_description`: *Audio- und Videowiedergabe stoppen* → *Medienwiedergabe stoppen*
- `screen_description`: *Bildschirm sperren wenn Timer endet (Shizuku optional)* → *Display ausschalten (Shizuku optional)*
- `wifi_off_description` / `bluetooth_off_description`: drop redundant *wenn Timer endet*, phrasing now *(Shizuku benötigt)*

## Test plan
- [ ] Open settings in German locale and verify the four rows read as above
- [ ] Confirm English strings are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)