### PR TITLE
feat(timer): enlarge dial to use more screen space

### DIFF
--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -116,7 +116,7 @@ private fun TimerContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
-                    .padding(horizontal = 56.dp),
+                    .padding(horizontal = 40.dp),
                 contentAlignment = Alignment.Center,
             ) {
                 CircularDial(
@@ -127,7 +127,7 @@ private fun TimerContent(
                     onMinutesChanged = { viewModel.setMinutes(it) },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .sizeIn(maxWidth = 320.dp, maxHeight = 320.dp),
+                        .sizeIn(maxWidth = 360.dp, maxHeight = 360.dp),
                 )
 
                 when (val s = uiState) {


### PR DESCRIPTION
## Summary
- Reduce horizontal padding around the dial from `56.dp` to `40.dp`
- Bump dial `sizeIn` max from `320.dp` to `360.dp`

Net effect: on narrow screens the smaller padding gives the dial more room; on wider screens the higher cap lets it grow further.

## Test plan
- [ ] Launch app, confirm dial visibly larger on phone-sized screen
- [ ] Verify drag gesture still works across the full ring
- [ ] Verify time display stays centered inside the dial
- [ ] Check on a wider screen (tablet/landscape) that the 360dp cap looks balanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)