### PR TITLE
feat(timer): persist preset minutes across app restarts

### DIFF
--- a/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/model/UserSettings.kt
+++ b/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/model/UserSettings.kt
@@ -11,4 +11,5 @@ data class UserSettings(
     val theme: ThemeId = ThemeId.Default,
     val starsEnabled: Boolean = true,
     val stepMinutes: Int = 5,
+    val presetMinutes: Int = 15,
 )

--- a/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/repository/SettingsRepository.kt
+++ b/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/repository/SettingsRepository.kt
@@ -16,4 +16,5 @@ interface SettingsRepository {
     suspend fun updateTheme(theme: ThemeId)
     suspend fun updateStarsEnabled(enabled: Boolean)
     suspend fun updateStepMinutes(minutes: Int)
+    suspend fun updatePresetMinutes(minutes: Int)
 }

--- a/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/repository/SettingsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/repository/SettingsRepositoryImpl.kt
@@ -29,6 +29,7 @@ class SettingsRepositoryImpl @Inject constructor(
         val THEME = stringPreferencesKey("theme")
         val STARS_ENABLED = booleanPreferencesKey("stars_enabled")
         val STEP_MINUTES = intPreferencesKey("step_minutes")
+        val PRESET_MINUTES = intPreferencesKey("preset_minutes")
     }
 
     override val settings: Flow<UserSettings> = dataStore.data.map { prefs ->
@@ -43,6 +44,7 @@ class SettingsRepositoryImpl @Inject constructor(
             theme = ThemeId.fromStorage(prefs[THEME]),
             starsEnabled = prefs[STARS_ENABLED] ?: true,
             stepMinutes = prefs[STEP_MINUTES] ?: 5,
+            presetMinutes = prefs[PRESET_MINUTES] ?: 15,
         )
     }
 
@@ -84,5 +86,9 @@ class SettingsRepositoryImpl @Inject constructor(
 
     override suspend fun updateStepMinutes(minutes: Int) {
         dataStore.edit { it[STEP_MINUTES] = minutes.coerceIn(1, 30) }
+    }
+
+    override suspend fun updatePresetMinutes(minutes: Int) {
+        dataStore.edit { it[PRESET_MINUTES] = minutes.coerceIn(1, 300) }
     }
 }

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerViewModel.kt
@@ -14,13 +14,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class TimerViewModel @Inject constructor(
     private val timerRepository: TimerRepository,
-    settingsRepository: SettingsRepository,
+    private val settingsRepository: SettingsRepository,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
@@ -28,6 +30,12 @@ class TimerViewModel @Inject constructor(
 
     val settings: StateFlow<UserSettings> = settingsRepository.settings
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), UserSettings())
+
+    init {
+        viewModelScope.launch {
+            _selectedMinutes.value = settingsRepository.settings.first().presetMinutes
+        }
+    }
 
     val uiState: StateFlow<TimerUiState> = combine(
         timerRepository.timerState,
@@ -55,7 +63,14 @@ class TimerViewModel @Inject constructor(
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TimerUiState.Idle())
 
     fun setMinutes(minutes: Int) {
-        _selectedMinutes.value = minutes.coerceIn(1, 300)
+        val coerced = minutes.coerceIn(1, 300)
+        _selectedMinutes.value = coerced
+        val phase = timerRepository.timerState.value.phase
+        if (phase == TimerPhase.IDLE || phase == TimerPhase.FINISHED) {
+            viewModelScope.launch {
+                settingsRepository.updatePresetMinutes(coerced)
+            }
+        }
     }
 
     fun startTimer() {


### PR DESCRIPTION
## Summary
- Add `presetMinutes` to `UserSettings` and a `PRESET_MINUTES` DataStore key in `SettingsRepository`.
- `TimerViewModel` seeds the dial from the persisted value on init and writes back through `updatePresetMinutes()` whenever the user changes it in `IDLE`/`FINISHED`.
- Dial changes during `RUNNING`/`FADING_OUT` are intentionally not persisted, so the saved preset reflects the user's chosen default rather than mid-run adjustments.

## Test plan
- [ ] Set the dial to a non-default value (e.g. 42), kill the app, relaunch — dial should restore to 42.
- [ ] Start the timer, then verify the preset stays at the value used to start (no overwrite while running).
- [ ] After the timer finishes, change the dial — value should be persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)