### PR TITLE
feat(timer): handle rotation in-app without relaunching activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.SleepTimer">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/docs/plans/2026-04-18-in-app-rotation-design.md
+++ b/docs/plans/2026-04-18-in-app-rotation-design.md
@@ -1,0 +1,58 @@
+# In-App Rotation Design
+
+**Date:** 2026-04-18
+**Status:** Approved, ready for implementation
+
+## Problem
+
+On device rotation the system recreates the Activity in landscape, which breaks the current TimerScreen layout — the dial overflows the screen. The layout is only designed for portrait.
+
+## Goal
+
+Keep the Activity locked to portrait and handle rotation *inside* Compose, rotating only text and icons while elements stay in place. The user (typically lying in bed) should be able to tilt the phone and still read the UI.
+
+## Approach
+
+### 1. Orientation detection & lock
+
+- Lock the Activity to portrait via `android:screenOrientation="portrait"` on `<activity>` in `app/src/main/AndroidManifest.xml`. Compose always renders the portrait layout regardless of physical pose.
+- Detect physical orientation with `OrientationEventListener`. Snap the continuous angle (0–359°) to four buckets — `PORTRAIT`, `LANDSCAPE_LEFT`, `PORTRAIT_REVERSED`, `LANDSCAPE_RIGHT` — with a ~30° hysteresis so small wobbles don't flip state.
+- Expose the result as a Compose `State<Orientation>` via a helper composable `rememberDeviceOrientation()` using `DisposableEffect` to manage the listener lifecycle. Scope: feature-local (only `TimerScreen` uses it).
+- All four orientations are supported, including 180° (reversed portrait).
+
+### 2. Layout in rotated state
+
+Only **two** layout states — portrait vs. rotated. The rotation *direction* (90° / 180° / 270°) only changes per-element rotation angles, not physical placement.
+
+| Element | Portrait | Rotated (physical placement) | Rendering rotation |
+|---|---|---|---|
+| TopBar title | centered in TopBar | right edge of screen, under the settings icon, vertical | `+angle` |
+| Settings icon | top-right corner | unchanged | `+angle` |
+| Dial (incl. numbers) | center | unchanged | `+angle` |
+| "Endet um" text | under dial, centered | under dial, centered (may shift slightly) | `+angle` |
+| Minus / Play / Plus row | bottom row | unchanged | icons only get `+angle` |
+
+`angle` is the counter-rotation of the device pose — e.g. device tilted 90° CW → content rotates –90° so it reads upright to the user.
+
+**Title placement in rotated mode:** directly below the settings icon on the right edge, ~8dp gap, rendered as a vertical banner (height ≈ 120dp).
+
+### 3. Animation
+
+- Single `animateFloatAsState` in `TimerContent` computes `animatedAngle` from the target orientation angle, with `tween(350ms, FastOutSlowInEasing)`.
+- The same `animatedAngle` is threaded down to every rotating element (dial, time display, "Endet um" text, button icons, title, settings icon). All rotate synchronously.
+- Rotations are applied via `Modifier.graphicsLayer { rotationZ = animatedAngle }`, rotating around each element's center.
+- **Shortest-path guard:** when the target angle jumps (e.g. 90° → –90°), remember the last angle and pick the "continue rotating same direction" equivalent so the animation doesn't reverse. E.g. from 180° the next target is expressed as 270° rather than –90°.
+- **Title layout change (portrait ↔ rotated) — Crossfade:** render both positions simultaneously; fade the portrait title out and the edge title in over ~350ms, synchronised with the rotation animation. Simple and clean; the fade masks the positional discontinuity.
+- No animation for the "Endet um" box position shift (spec says it may shift). Buttons don't move at all — only the icons inside rotate.
+
+## Files expected to change
+
+- `app/src/main/AndroidManifest.xml` — add `screenOrientation="portrait"`.
+- `feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt` — rotated layout branch, animated angle threading.
+- New: `feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/DeviceOrientation.kt` — enum + `rememberDeviceOrientation()`.
+- Button / icon components under `feature/timer/.../timer/components/` — accept an `iconRotation: Float` parameter.
+
+## Out of scope
+
+- Settings screen rotation (stays portrait-only, since the Activity is locked).
+- About screen rotation (same).

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/DeviceOrientation.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/DeviceOrientation.kt
@@ -1,0 +1,61 @@
+package dev.xitee.sleeptimer.feature.timer.timer
+
+import android.view.OrientationEventListener
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+enum class DeviceOrientation(val degrees: Int) {
+    PORTRAIT(0),
+    LANDSCAPE_LEFT(90),
+    PORTRAIT_REVERSED(180),
+    LANDSCAPE_RIGHT(270),
+}
+
+fun DeviceOrientation.counterRotationDegrees(): Float = when (this) {
+    DeviceOrientation.PORTRAIT -> 0f
+    DeviceOrientation.LANDSCAPE_LEFT -> -90f
+    DeviceOrientation.PORTRAIT_REVERSED -> 180f
+    DeviceOrientation.LANDSCAPE_RIGHT -> 90f
+}
+
+@Composable
+fun rememberDeviceOrientation(): State<DeviceOrientation> {
+    val context = LocalContext.current
+    val state = remember { mutableStateOf(DeviceOrientation.PORTRAIT) }
+
+    DisposableEffect(Unit) {
+        val listener = object : OrientationEventListener(context) {
+            override fun onOrientationChanged(orientation: Int) {
+                if (orientation == ORIENTATION_UNKNOWN) return
+                val next = snapToOrientation(orientation, state.value)
+                if (next != state.value) {
+                    state.value = next
+                }
+            }
+        }
+        if (listener.canDetectOrientation()) {
+            listener.enable()
+        }
+        onDispose { listener.disable() }
+    }
+
+    return state
+}
+
+// Hysteresis: stick with the current bucket until the device pose is more than
+// 60° away from its centre — 15° past the natural 45° boundary — so small wobbles
+// don't flip state.
+private fun snapToOrientation(degrees: Int, current: DeviceOrientation): DeviceOrientation {
+    val normalized = ((degrees % 360) + 360) % 360
+    if (shortestAngularDistance(normalized, current.degrees) <= 60) return current
+    return DeviceOrientation.entries.minBy { shortestAngularDistance(normalized, it.degrees) }
+}
+
+private fun shortestAngularDistance(a: Int, b: Int): Int {
+    val diff = kotlin.math.abs(a - b)
+    return kotlin.math.min(diff, 360 - diff)
+}

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -5,8 +5,16 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -17,7 +25,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove
@@ -30,10 +40,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -52,6 +65,8 @@ import dev.xitee.sleeptimer.feature.timer.timer.components.SecondaryRoundButton
 import dev.xitee.sleeptimer.feature.timer.timer.components.TimeDisplay
 import dev.xitee.sleeptimer.feature.timer.timer.components.TimerBackground
 import dev.xitee.sleeptimer.feature.timer.timer.components.rememberCircularDialState
+
+private const val ROTATION_DURATION_MS = 350
 
 @Composable
 fun TimerScreen(
@@ -77,6 +92,11 @@ private fun TimerContent(
     val settings by viewModel.settings.collectAsStateWithLifecycle()
     val dialState = rememberCircularDialState()
     val context = LocalContext.current
+
+    val orientation by rememberDeviceOrientation()
+    val isLandscape = orientation == DeviceOrientation.LANDSCAPE_LEFT ||
+        orientation == DeviceOrientation.LANDSCAPE_RIGHT
+    val animatedAngle = animatedRotationAngle(orientation)
 
     val notificationPermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
@@ -112,7 +132,11 @@ private fun TimerContent(
                 .windowInsetsPadding(WindowInsets.systemBars),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            HomeTopBar(onOpenSettings = onNavigateToSettings)
+            HomeTopBar(
+                onOpenSettings = onNavigateToSettings,
+                iconRotation = animatedAngle,
+                showInlineTitle = !isLandscape,
+            )
 
             val nowMillis by produceState(initialValue = System.currentTimeMillis()) {
                 while (true) {
@@ -130,19 +154,41 @@ private fun TimerContent(
                 android.text.format.DateFormat.getTimeFormat(context)
             }
 
-            Box(
+            BoxWithConstraints(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
                     .padding(horizontal = 40.dp),
                 contentAlignment = Alignment.Center,
             ) {
+                // In landscape, "Endet um" should sit exactly at the midpoint between
+                // the dial's bottom and the flex area's bottom (= button row top), with
+                // equal air above and below it. The required shift depends on the flex
+                // area height and the actual dial size, so compute it from constraints
+                // rather than picking a fixed value.
+                val dialSize = minOf(maxWidth, 360.dp)
+                val endetHeight = 24.dp
+                val dialToEndetGap = 20.dp
+                val groupTop = (maxHeight - dialSize - dialToEndetGap - endetHeight) / 2
+                val dialBottom = groupTop + dialSize
+                val portraitEndetCenter = dialBottom + dialToEndetGap + endetHeight / 2
+                val landscapeEndetCenter = (dialBottom + maxHeight) / 2
+                val targetShift = (landscapeEndetCenter - portraitEndetCenter)
+                    .coerceAtLeast(0.dp)
+                val endetShift by animateDpAsState(
+                    targetValue = if (isLandscape) targetShift else 0.dp,
+                    animationSpec = tween(ROTATION_DURATION_MS, easing = FastOutSlowInEasing),
+                    label = "endetShift",
+                )
+
                 Column(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Box(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .graphicsLayer { rotationZ = animatedAngle },
                         contentAlignment = Alignment.Center,
                     ) {
                         CircularDial(
@@ -165,12 +211,12 @@ private fun TimerContent(
                         }
                     }
 
-                    Spacer(modifier = Modifier.height(20.dp))
+                    Spacer(modifier = Modifier.height(dialToEndetGap))
 
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(24.dp),
+                            .height(endetHeight),
                         contentAlignment = Alignment.Center,
                     ) {
                         if (endMillis != null) {
@@ -181,6 +227,10 @@ private fun TimerContent(
                                 ),
                                 style = MaterialTheme.typography.bodyLarge,
                                 color = appTheme().textDim,
+                                modifier = Modifier.graphicsLayer {
+                                    rotationZ = animatedAngle
+                                    translationY = endetShift.toPx()
+                                },
                             )
                         }
                     }
@@ -197,6 +247,7 @@ private fun TimerContent(
             ActionRow(
                 isRunning = isRunning,
                 hapticEnabled = settings.hapticFeedbackEnabled,
+                iconRotation = animatedAngle,
                 onToggle = {
                     if (isRunning) {
                         viewModel.stopTimer()
@@ -242,23 +293,87 @@ private fun TimerContent(
 
             Spacer(modifier = Modifier.height(32.dp))
         }
+
+        // Landscape title: appears on the right edge, immediately below the settings
+        // icon. The container is 44dp wide (matches settings icon) and right-padded
+        // by 8dp (matches TopBar's horizontal padding), so the title's centre sits on
+        // the same device x as the settings icon — i.e. inline with it from the user's
+        // tilted perspective. wrapContentSize(unbounded = true) lets the text measure
+        // its natural width instead of being clipped to the 44dp container.
+        AnimatedVisibility(
+            visible = isLandscape,
+            enter = fadeIn(animationSpec = tween(ROTATION_DURATION_MS)),
+            exit = fadeOut(animationSpec = tween(ROTATION_DURATION_MS)),
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .windowInsetsPadding(WindowInsets.systemBars)
+                .padding(top = 56.dp, end = 8.dp)
+                .width(44.dp)
+                .height(160.dp),
+        ) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(R.string.app_name),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = appTheme().textPrimary,
+                    softWrap = false,
+                    modifier = Modifier
+                        .wrapContentSize(unbounded = true)
+                        .graphicsLayer { rotationZ = animatedAngle },
+                )
+            }
+        }
     }
 }
 
 @Composable
-private fun HomeTopBar(onOpenSettings: () -> Unit) {
+private fun animatedRotationAngle(orientation: DeviceOrientation): Float {
+    // Shortest-path guard: when the bucket jumps, pick the equivalent target (±360°)
+    // closest to the previous value so the animation continues rotating rather than
+    // reversing through 0°.
+    val continuousTarget = remember { mutableFloatStateOf(0f) }
+    LaunchedEffect(orientation) {
+        val raw = orientation.counterRotationDegrees()
+        val last = continuousTarget.floatValue
+        val candidates = listOf(raw, raw + 360f, raw - 360f)
+        continuousTarget.floatValue = candidates.minBy { kotlin.math.abs(it - last) }
+    }
+    val animated by animateFloatAsState(
+        targetValue = continuousTarget.floatValue,
+        animationSpec = tween(ROTATION_DURATION_MS, easing = FastOutSlowInEasing),
+        label = "rotationAngle",
+    )
+    return animated
+}
+
+@Composable
+private fun HomeTopBar(
+    onOpenSettings: () -> Unit,
+    iconRotation: Float,
+    showInlineTitle: Boolean,
+) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .height(56.dp)
             .padding(horizontal = 8.dp),
     ) {
-        Text(
-            text = stringResource(R.string.app_name),
-            style = MaterialTheme.typography.titleLarge,
-            color = appTheme().textPrimary,
+        AnimatedVisibility(
+            visible = showInlineTitle,
+            enter = fadeIn(animationSpec = tween(ROTATION_DURATION_MS)),
+            exit = fadeOut(animationSpec = tween(ROTATION_DURATION_MS)),
             modifier = Modifier.align(Alignment.Center),
-        )
+        ) {
+            Text(
+                text = stringResource(R.string.app_name),
+                style = MaterialTheme.typography.titleLarge,
+                color = appTheme().textPrimary,
+                modifier = Modifier.graphicsLayer { rotationZ = iconRotation },
+            )
+        }
         IconButton(
             onClick = onOpenSettings,
             modifier = Modifier
@@ -269,6 +384,7 @@ private fun HomeTopBar(onOpenSettings: () -> Unit) {
                 imageVector = Icons.Default.Settings,
                 contentDescription = stringResource(R.string.settings),
                 tint = appTheme().textPrimary,
+                modifier = Modifier.graphicsLayer { rotationZ = iconRotation },
             )
         }
     }
@@ -278,6 +394,7 @@ private fun HomeTopBar(onOpenSettings: () -> Unit) {
 private fun ActionRow(
     isRunning: Boolean,
     hapticEnabled: Boolean,
+    iconRotation: Float,
     onToggle: () -> Unit,
     onMinusStep: () -> Unit,
     onPlusStep: () -> Unit,
@@ -298,11 +415,13 @@ private fun ActionRow(
             onClick = onMinusStep,
             hapticEnabled = hapticEnabled,
             enabled = isMinusEnabled,
+            iconRotation = iconRotation,
         )
         PlayButton(
             isRunning = isRunning,
             hapticEnabled = hapticEnabled,
             onClick = onToggle,
+            iconRotation = iconRotation,
         )
         SecondaryRoundButton(
             icon = Icons.Default.Add,
@@ -310,6 +429,7 @@ private fun ActionRow(
             onClick = onPlusStep,
             hapticEnabled = hapticEnabled,
             enabled = if (isRunning) plusStepVisibleWhileRunning else isPlusEnabled,
+            iconRotation = iconRotation,
         )
     }
 }

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/components/PlayButton.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/components/PlayButton.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
@@ -39,6 +40,7 @@ fun PlayButton(
     hapticEnabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    iconRotation: Float = 0f,
 ) {
     val theme = appTheme()
     val view = LocalView.current
@@ -104,7 +106,9 @@ fun PlayButton(
                 imageVector = icon,
                 contentDescription = desc,
                 tint = theme.accentInk,
-                modifier = Modifier.size(34.dp),
+                modifier = Modifier
+                    .size(34.dp)
+                    .graphicsLayer { rotationZ = iconRotation },
             )
         }
     }
@@ -118,6 +122,7 @@ fun SecondaryRoundButton(
     hapticEnabled: Boolean,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    iconRotation: Float = 0f,
 ) {
     val theme = appTheme()
     val view = LocalView.current
@@ -141,7 +146,9 @@ fun SecondaryRoundButton(
             imageVector = icon,
             contentDescription = contentDescription,
             tint = if (enabled) theme.textPrimary else theme.textFaint,
-            modifier = Modifier.size(22.dp),
+            modifier = Modifier
+                .size(22.dp)
+                .graphicsLayer { rotationZ = iconRotation },
         )
     }
 }


### PR DESCRIPTION
## Summary
- Lock `MainActivity` to portrait and detect device pose via `OrientationEventListener`, then rotate text/icons inside Compose so the UI stays readable when the phone is tilted — the dial no longer overflows on system rotation.
- Landscape layout: title moves from TopBar centre to the right edge (inline with the settings icon), and "Endet um" slides down via `translationY` so it sits midway between the dial and the buttons. The required shift is computed from `BoxWithConstraints`, so the dial stays put on any screen size.
- Reverse portrait (180°): same physical layout as portrait, just every element rotated 180° — the text reuses exactly the same space it had upright.
- All rotating elements share one animated angle (shortest-path aware, 350ms tween) so the effect reads as a single synchronised rotation.

Design doc: `docs/plans/2026-04-18-in-app-rotation-design.md`.

## Test plan
- [ ] Tilt the phone 90° in either direction on the timer screen: dial contents rotate, title appears next to the settings icon on the right edge, "Endet um" sits centred between dial and buttons, all button icons rotate.
- [ ] Tilt to 180° (upside down): title stays in the TopBar centre and "Endet um" stays in its portrait position, just rotated 180°.
- [ ] Rotate between the four orientations several times: rotation always takes the shortest visual path without snap-back.
- [ ] Navigate to settings / about and back: rotation state recovers correctly; those screens remain portrait-only.
- [ ] Verify on a smaller device that the dial position doesn't shift when "Endet um" slides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)