### PR TITLE
feat(timer): allow dial adjustment while timer is running

### DIFF
--- a/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/SleepTimerService.kt
+++ b/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/SleepTimerService.kt
@@ -57,7 +57,9 @@ class SleepTimerService : Service() {
         const val ACTION_CANCEL = "dev.xitee.sleeptimer.action.CANCEL"
         const val ACTION_ADD_MINUTES = "dev.xitee.sleeptimer.action.ADD_MINUTES"
         const val ACTION_SUBTRACT_MINUTES = "dev.xitee.sleeptimer.action.SUBTRACT_MINUTES"
+        const val ACTION_SET_MINUTES = "dev.xitee.sleeptimer.action.SET_MINUTES"
         const val EXTRA_DURATION_MILLIS = "dev.xitee.sleeptimer.extra.DURATION_MILLIS"
+        const val EXTRA_MINUTES = "dev.xitee.sleeptimer.extra.MINUTES"
         private const val FADE_IN_SECONDS = 2
     }
 
@@ -98,6 +100,10 @@ class SleepTimerService : Service() {
             }
             ACTION_SUBTRACT_MINUTES -> {
                 subtractStep()
+            }
+            ACTION_SET_MINUTES -> {
+                val minutes = intent.getIntExtra(EXTRA_MINUTES, 0)
+                if (minutes > 0) setRemainingMinutes(minutes)
             }
             ACTION_CANCEL -> {
                 cancelTimer()
@@ -195,6 +201,19 @@ class SleepTimerService : Service() {
             }
             else -> {}
         }
+    }
+
+    private fun setRemainingMinutes(minutes: Int) {
+        if (timerRepository.timerState.value.phase != TimerPhase.RUNNING) return
+        if (countdownJob?.isActive != true) return
+        val newRemaining = minutes * 60 * 1000L
+        remainingMillis = newRemaining
+        totalDurationMillis = maxOf(totalDurationMillis, newRemaining)
+        updateTimerState(TimerPhase.RUNNING)
+        notificationManager.updateNotification(
+            remainingMillisToDisplayMinutes(remainingMillis),
+            stepMinutes,
+        )
     }
 
     private fun subtractStep() {

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -122,6 +122,14 @@ private fun TimerContent(
         else -> 0f
     }
 
+    val displayMinutes: Int = if (dialState.isDragging) {
+        dialState.totalMinutes
+    } else when (val s = uiState) {
+        is TimerUiState.Idle -> s.selectedMinutes
+        is TimerUiState.Running -> remainingMillisToDisplayMinutes(s.remainingMillis)
+        is TimerUiState.FadingOut -> 0
+    }
+
     TimerBackground(
         animating = isRunning,
         starsEnabled = settings.starsEnabled,
@@ -145,11 +153,10 @@ private fun TimerContent(
                     kotlinx.coroutines.delay(10_000L)
                 }
             }
-            val endMillis: Long? = when (val s = uiState) {
-                is TimerUiState.Idle ->
-                    if (s.selectedMinutes > 0) nowMillis + s.selectedMinutes * 60_000L else null
-                is TimerUiState.Running -> nowMillis + s.remainingMillis
-                is TimerUiState.FadingOut -> null
+            val endMillis: Long? = if (uiState is TimerUiState.FadingOut || displayMinutes <= 0) {
+                null
+            } else {
+                nowMillis + displayMinutes * 60_000L
             }
             val timeFormatter = remember(context) {
                 android.text.format.DateFormat.getTimeFormat(context)
@@ -222,18 +229,12 @@ private fun TimerContent(
                             isRunning = isRunning,
                             runningMinutes = runningMinutes,
                             hapticEnabled = settings.hapticFeedbackEnabled,
-                            onMinutesChanged = { viewModel.setMinutes(it) },
-                            onMinutesCommitted = { viewModel.commitMinutes(it) },
+                            onMinutesChanged = viewModel::setMinutes,
+                            onMinutesCommitted = viewModel::commitMinutes,
                             modifier = Modifier.fillMaxSize(),
                         )
 
-                        when (val s = uiState) {
-                            is TimerUiState.Idle -> TimeDisplay(totalMinutes = s.selectedMinutes)
-                            is TimerUiState.Running -> TimeDisplay(
-                                totalMinutes = remainingMillisToDisplayMinutes(s.remainingMillis),
-                            )
-                            is TimerUiState.FadingOut -> TimeDisplay(totalMinutes = 0)
-                        }
+                        TimeDisplay(totalMinutes = displayMinutes)
                     }
 
                     Spacer(modifier = Modifier.height(dialToEndetGap))

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerViewModel.kt
@@ -10,6 +10,7 @@ import dev.xitee.sleeptimer.core.data.model.TimerPhase
 import dev.xitee.sleeptimer.core.data.model.UserSettings
 import dev.xitee.sleeptimer.core.data.repository.SettingsRepository
 import dev.xitee.sleeptimer.core.data.repository.TimerRepository
+import dev.xitee.sleeptimer.core.data.util.remainingMillisToDisplayMinutes
 import dev.xitee.sleeptimer.core.service.SleepTimerService
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -66,22 +67,36 @@ class TimerViewModel @Inject constructor(
     /**
      * Updates the live UI minutes without persisting. Called continuously during a
      * dial drag — persisting every tick would flood DataStore with ~30 writes per drag.
+     * Ignored while a timer is running: during-drag previews are driven by dialState
+     * in the UI, and updating `_selectedMinutes` would silently shift the idle preset
+     * once the running session ends.
      */
     fun setMinutes(minutes: Int) {
+        val phase = timerRepository.timerState.value.phase
+        if (phase != TimerPhase.IDLE && phase != TimerPhase.FINISHED) return
         _selectedMinutes.value = minutes.coerceIn(1, 300)
     }
 
     /**
-     * Updates and persists the preset. Called from +/- step buttons (single discrete
-     * change) and from dial `onDragEnd` (one write at the end of a drag).
+     * Applies a committed minutes value. When idle, persists it as the preset. When a
+     * timer is running, dispatches to the service to adjust remaining time.
      */
     fun commitMinutes(minutes: Int) {
         val coerced = minutes.coerceIn(1, 300)
-        _selectedMinutes.value = coerced
-        val phase = timerRepository.timerState.value.phase
-        if (phase == TimerPhase.IDLE || phase == TimerPhase.FINISHED) {
-            viewModelScope.launch {
-                settingsRepository.updatePresetMinutes(coerced)
+        val state = timerRepository.timerState.value
+        when (state.phase) {
+            TimerPhase.RUNNING -> {
+                if (remainingMillisToDisplayMinutes(state.remainingMillis) == coerced) return
+                val intent = serviceIntent(SleepTimerService.ACTION_SET_MINUTES).apply {
+                    putExtra(SleepTimerService.EXTRA_MINUTES, coerced)
+                }
+                context.startService(intent)
+            }
+            else -> {
+                _selectedMinutes.value = coerced
+                viewModelScope.launch {
+                    settingsRepository.updatePresetMinutes(coerced)
+                }
             }
         }
     }

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/components/CircularDial.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/components/CircularDial.kt
@@ -55,7 +55,11 @@ fun CircularDial(
     }
     var lastReportedMinutes by remember { mutableStateOf(state.totalMinutes) }
 
-    val targetMinutes: Float = if (isRunning) runningMinutes else state.totalMinutes.toFloat()
+    val targetMinutes: Float = if (isRunning && !state.isDragging) {
+        runningMinutes
+    } else {
+        state.totalMinutes.toFloat()
+    }
     val animatedMinutes = remember { Animatable(targetMinutes) }
     LaunchedEffect(targetMinutes, state.isDragging) {
         val delta = kotlin.math.abs(targetMinutes - animatedMinutes.value)
@@ -82,46 +86,48 @@ fun CircularDial(
         Canvas(
             modifier = Modifier
                 .fillMaxSize()
-                .then(
-                    if (!isRunning) {
-                        Modifier.pointerInput(Unit) {
-                            detectDragGestures(
-                                onDragStart = { offset ->
-                                    state.onDragStart(
-                                        centerX = size.width / 2f,
-                                        centerY = size.height / 2f,
-                                        x = offset.x,
-                                        y = offset.y,
-                                    )
-                                },
-                                onDrag = { change, _ ->
-                                    change.consume()
-                                    state.onDrag(
-                                        centerX = size.width / 2f,
-                                        centerY = size.height / 2f,
-                                        x = change.position.x,
-                                        y = change.position.y,
-                                    )
-                                    if (state.totalMinutes != lastReportedMinutes) {
-                                        if (hapticEnabled) {
-                                            view.performHapticFeedback(tickHapticType)
-                                        }
-                                        lastReportedMinutes = state.totalMinutes
-                                        onMinutesChanged(state.totalMinutes)
-                                    }
-                                },
-                                onDragEnd = {
-                                    state.onDragEnd()
-                                    // Persist only at drag end to avoid DataStore write flood
-                                    // during the gesture (30+ writes/sec otherwise).
-                                    onMinutesCommitted(state.totalMinutes)
-                                },
+                .pointerInput(Unit) {
+                    detectDragGestures(
+                        onDragStart = { offset ->
+                            // While running, dialState tracks the last idle preset, not
+                            // the ticking remaining time. Seed it to the currently-shown
+                            // minutes so the drag continues from the right position.
+                            if (isRunning) {
+                                val seed = kotlin.math.ceil(runningMinutes.coerceAtLeast(0f))
+                                    .toInt().coerceIn(1, 300)
+                                state.setMinutes(seed)
+                            }
+                            state.onDragStart(
+                                centerX = size.width / 2f,
+                                centerY = size.height / 2f,
+                                x = offset.x,
+                                y = offset.y,
                             )
-                        }
-                    } else {
-                        Modifier
-                    },
-                ),
+                        },
+                        onDrag = { change, _ ->
+                            change.consume()
+                            state.onDrag(
+                                centerX = size.width / 2f,
+                                centerY = size.height / 2f,
+                                x = change.position.x,
+                                y = change.position.y,
+                            )
+                            if (state.totalMinutes != lastReportedMinutes) {
+                                if (hapticEnabled) {
+                                    view.performHapticFeedback(tickHapticType)
+                                }
+                                lastReportedMinutes = state.totalMinutes
+                                onMinutesChanged(state.totalMinutes)
+                            }
+                        },
+                        onDragEnd = {
+                            state.onDragEnd()
+                            // Persist only at drag end to avoid DataStore write flood
+                            // during the gesture (30+ writes/sec otherwise).
+                            onMinutesCommitted(state.totalMinutes)
+                        },
+                    )
+                },
         ) {
             val strokeWidth = 14.dp.toPx()
             val plateInset = 6.dp.toPx()
@@ -192,7 +198,7 @@ fun CircularDial(
                 radius = radius,
                 fraction = ringFraction,
                 theme = theme,
-                dimmed = isRunning,
+                dimmed = isRunning && !state.isDragging,
             )
         }
     }


### PR DESCRIPTION
## Summary
- Dial is now interactive while a timer is running — drag to set the remaining time directly (previously only +/- worked).
- New `ACTION_SET_MINUTES` on `SleepTimerService` applies an absolute remaining-minutes value; `TimerViewModel.commitMinutes` routes by phase (RUNNING → service, else persist preset).
- Drag start seeds dial state from the current remaining minutes so the gesture picks up at the right position without a continuous sync loop.

## Test plan
- [ ] Idle: dial still drags smoothly, release persists the new preset.
- [ ] Running: drag the dial, the centre time + "Endet um" preview track the drag; releasing applies the new remaining time.
- [ ] Running: +/- buttons still step as before.
- [ ] After a running-drag, the idle preset is unchanged (next start uses the original preset, not the dragged value).
- [ ] Haptic ticks fire during drag in both states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)