### PR TITLE
chore(release): adopt versionCode scheme and scope signing secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   build-release:
     name: Build release APK
     runs-on: ubuntu-latest
+    environment: release
     timeout-minutes: 30
 
     steps:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,8 @@ android {
         applicationId = "dev.xitee.sleeptimer"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
+        // Schema: major * 100000 + minor * 1000 + patch * 10 (last digit reserved for hotfixes)
+        versionCode = 1 * 100000 + 0 * 1000 + 0 * 10
         versionName = "1.0.0"
     }
 


### PR DESCRIPTION
## Summary
- Switch `versionCode` to `major*100000 + minor*1000 + patch*10` (1.0.0 = 100000), leaving room for minor/patch/hotfix bumps without ever colliding.
- Bind the release workflow to a new `release` GitHub Environment so the signing secrets are only injected on `v*` tag runs, not on PR or branch builds.

## Required setup before next release
- Create environment `release` in repo settings.
- Restrict deployment tags: pattern `v*`.
- Add the four secrets (`SIGNING_KEYSTORE_BASE64`, `SIGNING_KEYSTORE_PASSWORD`, `SIGNING_KEY_ALIAS`, `SIGNING_KEY_PASSWORD`) to that environment, not as repository secrets.

## Test plan
- [ ] Verify CI still passes on this PR (no signing needed for debug build).
- [ ] After merge, create environment + secrets, then push a `v1.0.0` tag and confirm the release workflow signs and attaches the APK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)