### PR TITLE
chore(deps): upgrade to AGP 9 / Kotlin 2.3 / Compose BOM 2026.03

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt.android)
@@ -9,12 +8,12 @@ plugins {
 
 android {
     namespace = "dev.xitee.sleeptimer"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "dev.xitee.sleeptimer"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0.0"
     }
@@ -54,12 +53,14 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         compose = true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xannotation-default-target=param-property")
     }
 }
 
@@ -83,6 +84,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.hilt.lifecycle.viewmodel.compose)
     implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.hilt.android)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.hilt.android) apply false

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,13 +1,12 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.hilt.android)
     alias(libs.plugins.ksp)
 }
 
 android {
     namespace = "dev.xitee.sleeptimer.core.data"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 26
@@ -17,9 +16,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+}
 
-    kotlinOptions {
-        jvmTarget = "17"
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xannotation-default-target=param-property")
     }
 }
 

--- a/core/service/build.gradle.kts
+++ b/core/service/build.gradle.kts
@@ -1,13 +1,12 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.hilt.android)
     alias(libs.plugins.ksp)
 }
 
 android {
     namespace = "dev.xitee.sleeptimer.core.service"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 26
@@ -17,9 +16,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+}
 
-    kotlinOptions {
-        jvmTarget = "17"
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xannotation-default-target=param-property")
     }
 }
 

--- a/feature/timer/build.gradle.kts
+++ b/feature/timer/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.hilt.android)
     alias(libs.plugins.ksp)
@@ -8,7 +7,7 @@ plugins {
 
 android {
     namespace = "dev.xitee.sleeptimer.feature.timer"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 26
@@ -19,12 +18,14 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         compose = true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xannotation-default-target=param-property")
     }
 }
 
@@ -45,6 +46,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.hilt.lifecycle.viewmodel.compose)
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/about/AboutScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/about/AboutScreen.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.xitee.sleeptimer.feature.timer.R
 import dev.xitee.sleeptimer.feature.timer.theme.AppThemes

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsScreen.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsScreen.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -98,7 +97,11 @@ private fun SettingsContent(
     onNavigateToAbout: () -> Unit,
     viewModel: SettingsViewModel,
 ) {
-    val context = LocalContext.current
+    val screenDescription = stringResource(R.string.screen_description)
+    val shizukuSoftScreenOffExplanation =
+        stringResource(R.string.shizuku_feature_soft_screen_off)
+    val shizukuWifiExplanation = stringResource(R.string.shizuku_feature_wifi)
+    val shizukuBluetoothExplanation = stringResource(R.string.shizuku_feature_bluetooth)
 
     val deviceAdminLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult(),
@@ -148,14 +151,14 @@ private fun SettingsContent(
                         )
                         putExtra(
                             DevicePolicyManager.EXTRA_ADD_EXPLANATION,
-                            context.getString(R.string.screen_description),
+                            screenDescription,
                         )
                     }
                     deviceAdminLauncher.launch(intent)
                 }
             },
             onSoftLockSelected = {
-                requestWithShizuku(context.getString(R.string.shizuku_feature_soft_screen_off)) {
+                requestWithShizuku(shizukuSoftScreenOffExplanation) {
                     viewModel.updateScreenOff(true)
                     viewModel.updateSoftScreenOff(true)
                 }
@@ -266,7 +269,7 @@ private fun SettingsContent(
                     checked = uiState.settings.turnOffWifi,
                     onCheckedChange = { enabled ->
                         if (enabled) {
-                            requestWithShizuku(context.getString(R.string.shizuku_feature_wifi)) {
+                            requestWithShizuku(shizukuWifiExplanation) {
                                 viewModel.updateTurnOffWifi(true)
                             }
                         } else {
@@ -282,7 +285,7 @@ private fun SettingsContent(
                     checked = uiState.settings.turnOffBluetooth,
                     onCheckedChange = { enabled ->
                         if (enabled) {
-                            requestWithShizuku(context.getString(R.string.shizuku_feature_bluetooth)) {
+                            requestWithShizuku(shizukuBluetoothExplanation) {
                                 viewModel.updateTurnOffBluetooth(true)
                             }
                         } else {

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/ThemePickerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/ThemePickerScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.xitee.sleeptimer.core.data.model.ThemeId
 import dev.xitee.sleeptimer.feature.timer.R

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -99,6 +99,7 @@ private fun TimerContent(
     val settings by viewModel.settings.collectAsStateWithLifecycle()
     val dialState = rememberCircularDialState()
     val context = LocalContext.current
+    val screenDescription = stringResource(R.string.screen_description)
 
     val orientation by rememberDeviceOrientation()
     val isLandscape = orientation == DeviceOrientation.LANDSCAPE_LEFT ||
@@ -145,7 +146,7 @@ private fun TimerContent(
                     )
                     putExtra(
                         DevicePolicyManager.EXTRA_ADD_EXPLANATION,
-                        context.getString(R.string.screen_description),
+                        screenDescription,
                     )
                 }
                 adminStartupLauncher.launch(intent)

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.xitee.sleeptimer.core.data.util.remainingMillisToDisplayMinutes
 import dev.xitee.sleeptimer.feature.timer.R

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
-agp = "8.7.3"
-kotlin = "2.1.0"
-ksp = "2.1.0-1.0.29"
-hilt = "2.53.1"
-composeBom = "2024.12.01"
-androidxLifecycle = "2.8.7"
-androidxNavigation = "2.8.5"
-androidxHiltNavigationCompose = "1.2.0"
-androidxDatastore = "1.1.1"
-androidxCoreKtx = "1.15.0"
-androidxActivityCompose = "1.9.3"
-kotlinxSerializationJson = "1.7.3"
+agp = "9.1.1"
+kotlin = "2.3.20"
+ksp = "2.3.6"
+hilt = "2.59.2"
+composeBom = "2026.03.01"
+androidxLifecycle = "2.10.0"
+androidxNavigation = "2.9.7"
+androidxHiltNavigationCompose = "1.3.0"
+androidxDatastore = "1.2.1"
+androidxCoreKtx = "1.18.0"
+androidxActivityCompose = "1.13.0"
+kotlinxSerializationJson = "1.11.0"
 shizuku = "13.1.5"
 
 [libraries]
@@ -34,6 +34,7 @@ androidx-datastore-preferences = { group = "androidx.datastore", name = "datasto
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "androidxHiltNavigationCompose" }
+androidx-hilt-lifecycle-viewmodel-compose = { group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "androidxHiltNavigationCompose" }
 
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Sync the dependency set forward ~15 months; adopt AGP 9, Kotlin 2.3, Compose BOM 2026.03, Material3 1.4, Lifecycle 2.10, Navigation 2.9, DataStore 1.2, Activity 1.13; bump compileSdk/targetSdk to 36.
- Perform the AGP 9 structural migration: drop the `kotlin-android` plugin (Kotlin is now built in) and remove the `android.kotlinOptions` DSL.
- Migrate `hiltViewModel()` (4 call sites) to the new `androidx.hilt:hilt-lifecycle-viewmodel-compose` artifact required by Hilt Nav Compose 1.3.0.
- Opt in to the upcoming Kotlin annotation-default-target behaviour (`-Xannotation-default-target=param-property`) to resolve KT-73255 warnings on `@Inject` / `@StringRes` constructor params.

## Test plan
- [x] `./gradlew assembleDebug` — green, zero warnings
- [x] Install + launch on `emulator-5554` — app starts, MainActivity renders
- [ ] Timer core: start / dial-set / pause / resume / cancel / run-to-completion (screen-lock fires)
- [ ] Foreground service: notification appears, remaining-time updates, tap returns to app, survives device lock
- [ ] Rotation: Settings rotates portrait/landscape without dial/endet overlap; Timer stays portrait; rotation mid-run preserves state
- [ ] Persistence: change settings → kill app → relaunch → values retained (DataStore 1.1 → 1.2 wire check)
- [ ] Theme picker: cycle each theme, confirm gradient rendering in Timer screen
- [ ] Navigation: Settings → ThemePicker → back; Settings → About → back; system-back on every screen
- [ ] Edge-to-edge: status-bar colour holds through rotation and system dark-mode toggle (Activity 1.13 re-invokes EdgeToEdge on config changes)
- [ ] Shizuku flow: install/uninstall detection, permission request round-trip
- [ ] Clean install on Android 14+: `POST_NOTIFICATIONS` prompt appears on first timer start (targetSdk 36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)