### PR TITLE
fix: recover stranded screen-off permission prompt commits

### DIFF
--- a/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/screen/ScreenLockHelper.kt
+++ b/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/screen/ScreenLockHelper.kt
@@ -14,13 +14,15 @@ class ScreenLockHelper @Inject constructor(
     private val devicePolicyManager =
         context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
 
-    private val adminComponent = ComponentName(
+    val adminComponent: ComponentName = ComponentName(
         context,
         "dev.xitee.sleeptimer.receiver.SleepTimerDeviceAdminReceiver",
     )
 
+    fun isAdminActive(): Boolean = devicePolicyManager.isAdminActive(adminComponent)
+
     fun lockScreen(): Boolean {
-        return if (devicePolicyManager.isAdminActive(adminComponent)) {
+        return if (isAdminActive()) {
             devicePolicyManager.lockNow()
             true
         } else {

--- a/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/shizuku/ShizukuManager.kt
+++ b/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/shizuku/ShizukuManager.kt
@@ -6,6 +6,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
 import rikka.shizuku.Shizuku
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -25,7 +27,15 @@ class ShizukuManager @Inject constructor(
     private val _state = MutableStateFlow(computeState())
     val state: StateFlow<State> = _state.asStateFlow()
 
-    private val binderReceived = Shizuku.OnBinderReceivedListener { refresh() }
+    // Flips true the first time the Shizuku binder connects this process.
+    // Before that, `pingBinder()` returning false is ambiguous — it may mean
+    // "not running" or simply "not yet received".
+    private val _binderReceivedOnce = MutableStateFlow(false)
+
+    private val binderReceived = Shizuku.OnBinderReceivedListener {
+        _binderReceivedOnce.value = true
+        refresh()
+    }
     private val binderDead = Shizuku.OnBinderDeadListener { refresh() }
     private val permissionResult = Shizuku.OnRequestPermissionResultListener { _, _ -> refresh() }
 
@@ -49,6 +59,22 @@ class ShizukuManager @Inject constructor(
         } catch (_: Exception) {
             refresh()
         }
+    }
+
+    /**
+     * Waits until the Shizuku binder connects (or timeout) before returning the
+     * state. Call this for startup checks so an early-boot `pingBinder()` race
+     * doesn't masquerade as NotRunning.
+     */
+    suspend fun awaitInitialState(timeoutMs: Long = 1500): State {
+        if (!isShizukuInstalled()) return State.NotInstalled
+        if (!_binderReceivedOnce.value) {
+            withTimeoutOrNull(timeoutMs) {
+                _binderReceivedOnce.first { it }
+            }
+        }
+        refresh()
+        return _state.value
     }
 
     private fun computeState(): State {

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsScreen.kt
@@ -247,8 +247,7 @@ private fun SettingsContent(
                     description = when {
                         !uiState.settings.screenOff -> stringResource(R.string.screen_description)
                         uiState.settings.softScreenOff -> stringResource(R.string.screen_method_active_soft)
-                        uiState.isDeviceAdminEnabled -> stringResource(R.string.screen_method_active_hard)
-                        else -> stringResource(R.string.screen_admin_required)
+                        else -> stringResource(R.string.screen_method_active_hard)
                     },
                     checked = uiState.settings.screenOff,
                     onCheckedChange = { enabled ->

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsUiState.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsUiState.kt
@@ -5,6 +5,5 @@ import dev.xitee.sleeptimer.core.service.shizuku.ShizukuManager
 
 data class SettingsUiState(
     val settings: UserSettings = UserSettings(),
-    val isDeviceAdminEnabled: Boolean = false,
     val shizukuState: ShizukuManager.State = ShizukuManager.State.NotInstalled,
 )

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsViewModel.kt
@@ -46,7 +46,6 @@ class SettingsViewModel @Inject constructor(
         ) { settings, shizukuState, _ ->
             SettingsUiState(
                 settings = settings,
-                isDeviceAdminEnabled = devicePolicyManager.isAdminActive(adminComponent),
                 shizukuState = shizukuState,
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/DeviceAdminRequiredDialog.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/DeviceAdminRequiredDialog.kt
@@ -27,7 +27,7 @@ fun DeviceAdminRequiredDialog(
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.shizuku_action_cancel))
+                Text(stringResource(R.string.dialog_action_ignore))
             }
         },
     )

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/DeviceAdminRequiredDialog.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/DeviceAdminRequiredDialog.kt
@@ -1,0 +1,30 @@
+package dev.xitee.sleeptimer.feature.timer.settings.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import dev.xitee.sleeptimer.feature.timer.R
+
+@Composable
+fun DeviceAdminRequiredDialog(
+    onRequestPermission: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.admin_dialog_title)) },
+        text = { Text(stringResource(R.string.admin_body_required)) },
+        confirmButton = {
+            TextButton(onClick = onRequestPermission) {
+                Text(stringResource(R.string.admin_action_grant))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.shizuku_action_cancel))
+            }
+        },
+    )
+}

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/DeviceAdminRequiredDialog.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/DeviceAdminRequiredDialog.kt
@@ -1,6 +1,9 @@
 package dev.xitee.sleeptimer.feature.timer.settings.components
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AdminPanelSettings
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -14,6 +17,7 @@ fun DeviceAdminRequiredDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.AdminPanelSettings, contentDescription = null) },
         title = { Text(stringResource(R.string.admin_dialog_title)) },
         text = { Text(stringResource(R.string.admin_body_required)) },
         confirmButton = {

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/ScreenLockMethodDialog.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/ScreenLockMethodDialog.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AdminPanelSettings
 import androidx.compose.material.icons.filled.Nightlight
+import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -33,6 +34,7 @@ fun ScreenLockMethodDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.PhoneAndroid, contentDescription = null) },
         title = { Text(stringResource(R.string.screen_method_dialog_title)) },
         text = {
             Column {
@@ -71,14 +73,14 @@ private fun MethodOption(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(vertical = 12.dp, horizontal = 4.dp),
+            .padding(vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(icon, contentDescription = null, modifier = Modifier.size(28.dp))
         Spacer(Modifier.width(16.dp))
         Column {
             Text(title, style = MaterialTheme.typography.titleMedium)
-            Text(description, style = MaterialTheme.typography.bodySmall)
+            Text(description, style = MaterialTheme.typography.bodyMedium)
         }
     }
 }

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/ShizukuRequiredDialog.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/ShizukuRequiredDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.annotation.StringRes
 import androidx.core.net.toUri
 import dev.xitee.sleeptimer.core.service.shizuku.ShizukuManager
 import dev.xitee.sleeptimer.feature.timer.R
@@ -44,6 +45,7 @@ fun ShizukuRequiredDialog(
     onRequestPermission: () -> Unit,
     onDismiss: () -> Unit,
     introText: String? = null,
+    @StringRes dismissLabelRes: Int = R.string.shizuku_action_cancel,
 ) {
     val context = LocalContext.current
 
@@ -116,7 +118,7 @@ fun ShizukuRequiredDialog(
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.shizuku_action_cancel))
+                Text(stringResource(dismissLabelRes))
             }
         },
     )

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/ShizukuRequiredDialog.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/ShizukuRequiredDialog.kt
@@ -4,7 +4,12 @@ import android.content.Intent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Security
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -85,18 +90,22 @@ fun ShizukuRequiredDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.Security, contentDescription = null) },
         title = { Text(stringResource(R.string.shizuku_dialog_title)) },
         text = {
-            Column {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 if (featureExplanations.size == 1 && introText == null) {
                     Text(featureExplanations.first())
                 } else {
-                    introText?.let { Text(it) }
+                    introText?.let {
+                        Text(it)
+                        Spacer(Modifier.height(8.dp))
+                    }
                     featureExplanations.forEach { explanation ->
                         Text("• $explanation", style = MaterialTheme.typography.bodyMedium)
                     }
                 }
-                Spacer(Modifier.height(12.dp))
+                Spacer(Modifier.height(16.dp))
                 Text(stringResource(bodyRes))
             }
         },

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/ShizukuRequiredDialog.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/ShizukuRequiredDialog.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -22,6 +23,22 @@ fun ShizukuRequiredDialog(
     featureExplanation: String,
     onRequestPermission: () -> Unit,
     onDismiss: () -> Unit,
+) {
+    ShizukuRequiredDialog(
+        state = state,
+        featureExplanations = listOf(featureExplanation),
+        onRequestPermission = onRequestPermission,
+        onDismiss = onDismiss,
+    )
+}
+
+@Composable
+fun ShizukuRequiredDialog(
+    state: ShizukuManager.State,
+    featureExplanations: List<String>,
+    onRequestPermission: () -> Unit,
+    onDismiss: () -> Unit,
+    introText: String? = null,
 ) {
     val context = LocalContext.current
 
@@ -71,7 +88,14 @@ fun ShizukuRequiredDialog(
         title = { Text(stringResource(R.string.shizuku_dialog_title)) },
         text = {
             Column {
-                Text(featureExplanation)
+                if (featureExplanations.size == 1 && introText == null) {
+                    Text(featureExplanations.first())
+                } else {
+                    introText?.let { Text(it) }
+                    featureExplanations.forEach { explanation ->
+                        Text("• $explanation", style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
                 Spacer(Modifier.height(12.dp))
                 Text(stringResource(bodyRes))
             }

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -1,6 +1,8 @@
 package dev.xitee.sleeptimer.feature.timer.timer
 
 import android.Manifest
+import android.app.admin.DevicePolicyManager
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -40,6 +42,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -55,7 +58,10 @@ import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.xitee.sleeptimer.core.data.util.remainingMillisToDisplayMinutes
+import dev.xitee.sleeptimer.core.service.shizuku.ShizukuManager
 import dev.xitee.sleeptimer.feature.timer.R
+import dev.xitee.sleeptimer.feature.timer.settings.components.DeviceAdminRequiredDialog
+import dev.xitee.sleeptimer.feature.timer.settings.components.ShizukuRequiredDialog
 import dev.xitee.sleeptimer.feature.timer.theme.AppThemes
 import dev.xitee.sleeptimer.feature.timer.theme.LocalAppTheme
 import dev.xitee.sleeptimer.feature.timer.theme.appTheme
@@ -103,6 +109,66 @@ private fun TimerContent(
         ActivityResultContracts.RequestPermission(),
     ) { _ ->
         viewModel.startTimer()
+    }
+
+    var showAdminStartupDialog by remember { mutableStateOf(false) }
+    var shizukuStartupFeatures by remember { mutableStateOf<List<ShizukuFeature>>(emptyList()) }
+    val shizukuState by viewModel.shizukuState.collectAsStateWithLifecycle()
+
+    val adminStartupLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { _ ->
+        showAdminStartupDialog = false
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.computeStartupPermissionCheck()?.let { check ->
+            showAdminStartupDialog = check.adminMissing
+            shizukuStartupFeatures = check.shizukuMissingFeatures
+        }
+    }
+
+    // Auto-close the Shizuku startup dialog once permission is granted.
+    LaunchedEffect(shizukuState) {
+        if (shizukuStartupFeatures.isNotEmpty() && shizukuState == ShizukuManager.State.Ready) {
+            shizukuStartupFeatures = emptyList()
+        }
+    }
+
+    if (showAdminStartupDialog) {
+        DeviceAdminRequiredDialog(
+            onRequestPermission = {
+                val intent = Intent(DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN).apply {
+                    putExtra(
+                        DevicePolicyManager.EXTRA_DEVICE_ADMIN,
+                        viewModel.getAdminComponent(),
+                    )
+                    putExtra(
+                        DevicePolicyManager.EXTRA_ADD_EXPLANATION,
+                        context.getString(R.string.screen_description),
+                    )
+                }
+                adminStartupLauncher.launch(intent)
+            },
+            onDismiss = { showAdminStartupDialog = false },
+        )
+    }
+
+    if (shizukuStartupFeatures.isNotEmpty()) {
+        val explanations = shizukuStartupFeatures.map { feature ->
+            when (feature) {
+                ShizukuFeature.SCREEN_OFF -> stringResource(R.string.shizuku_feature_label_display)
+                ShizukuFeature.WIFI -> stringResource(R.string.shizuku_feature_label_wifi)
+                ShizukuFeature.BLUETOOTH -> stringResource(R.string.shizuku_feature_label_bluetooth)
+            }
+        }
+        ShizukuRequiredDialog(
+            state = shizukuState,
+            featureExplanations = explanations,
+            introText = stringResource(R.string.shizuku_startup_intro),
+            onRequestPermission = { viewModel.requestShizukuPermission() },
+            onDismiss = { shizukuStartupFeatures = emptyList() },
+        )
     }
 
     val isRunning = uiState is TimerUiState.Running || uiState is TimerUiState.FadingOut

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerScreen.kt
@@ -166,6 +166,7 @@ private fun TimerContent(
             state = shizukuState,
             featureExplanations = explanations,
             introText = stringResource(R.string.shizuku_startup_intro),
+            dismissLabelRes = R.string.dialog_action_ignore,
             onRequestPermission = { viewModel.requestShizukuPermission() },
             onDismiss = { shizukuStartupFeatures = emptyList() },
         )

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerViewModel.kt
@@ -1,5 +1,6 @@
 package dev.xitee.sleeptimer.feature.timer.timer
 
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import androidx.lifecycle.ViewModel
@@ -12,6 +13,8 @@ import dev.xitee.sleeptimer.core.data.repository.SettingsRepository
 import dev.xitee.sleeptimer.core.data.repository.TimerRepository
 import dev.xitee.sleeptimer.core.data.util.remainingMillisToDisplayMinutes
 import dev.xitee.sleeptimer.core.service.SleepTimerService
+import dev.xitee.sleeptimer.core.service.screen.ScreenLockHelper
+import dev.xitee.sleeptimer.core.service.shizuku.ShizukuManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -25,6 +28,8 @@ import javax.inject.Inject
 class TimerViewModel @Inject constructor(
     private val timerRepository: TimerRepository,
     private val settingsRepository: SettingsRepository,
+    private val shizukuManager: ShizukuManager,
+    private val screenLockHelper: ScreenLockHelper,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
@@ -32,6 +37,12 @@ class TimerViewModel @Inject constructor(
 
     val settings: StateFlow<UserSettings> = settingsRepository.settings
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), UserSettings())
+
+    val shizukuState: StateFlow<ShizukuManager.State> = shizukuManager.state
+
+    // Guards the startup permission dialog so it fires once per process lifetime.
+    // Survives navigation (ViewModel is scoped to the Timer nav entry).
+    private var startupCheckDone = false
 
     init {
         viewModelScope.launch {
@@ -63,6 +74,27 @@ class TimerViewModel @Inject constructor(
             TimerPhase.FADING_OUT -> TimerUiState.FadingOut
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TimerUiState.Idle())
+
+    fun getAdminComponent(): ComponentName = screenLockHelper.adminComponent
+
+    fun refreshShizuku() = shizukuManager.refresh()
+    fun requestShizukuPermission() = shizukuManager.requestPermission()
+
+    suspend fun computeStartupPermissionCheck(): StartupPermissionCheck? {
+        if (startupCheckDone) return null
+        startupCheckDone = true
+        shizukuManager.refresh()
+        val s = settingsRepository.settings.first()
+        val shizukuReady = shizukuManager.isReady()
+        val adminActive = screenLockHelper.isAdminActive()
+        val adminMissing = s.screenOff && !s.softScreenOff && !adminActive
+        val shizukuFeatures = buildList {
+            if (s.screenOff && s.softScreenOff && !shizukuReady) add(ShizukuFeature.SCREEN_OFF)
+            if (s.turnOffWifi && !shizukuReady) add(ShizukuFeature.WIFI)
+            if (s.turnOffBluetooth && !shizukuReady) add(ShizukuFeature.BLUETOOTH)
+        }
+        return StartupPermissionCheck(adminMissing, shizukuFeatures)
+    }
 
     /**
      * Updates the live UI minutes without persisting. Called continuously during a
@@ -129,3 +161,10 @@ class TimerViewModel @Inject constructor(
             setClassName(context, SleepTimerService::class.java.name)
         }
 }
+
+data class StartupPermissionCheck(
+    val adminMissing: Boolean,
+    val shizukuMissingFeatures: List<ShizukuFeature>,
+)
+
+enum class ShizukuFeature { SCREEN_OFF, WIFI, BLUETOOTH }

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/timer/TimerViewModel.kt
@@ -83,9 +83,11 @@ class TimerViewModel @Inject constructor(
     suspend fun computeStartupPermissionCheck(): StartupPermissionCheck? {
         if (startupCheckDone) return null
         startupCheckDone = true
-        shizukuManager.refresh()
+        // Wait for Shizuku's binder to connect — a cold-start `pingBinder()` race
+        // would otherwise report NotRunning even when Shizuku is up.
+        val shizukuState = shizukuManager.awaitInitialState()
         val s = settingsRepository.settings.first()
-        val shizukuReady = shizukuManager.isReady()
+        val shizukuReady = shizukuState == ShizukuManager.State.Ready
         val adminActive = screenLockHelper.isAdminActive()
         val adminMissing = s.screenOff && !s.softScreenOff && !adminActive
         val shizukuFeatures = buildList {

--- a/feature/timer/src/main/res/values-de/strings.xml
+++ b/feature/timer/src/main/res/values-de/strings.xml
@@ -30,7 +30,6 @@
     <string name="step_minutes_value">%d Min</string>
     <string name="screen_title">Bildschirm</string>
     <string name="screen_description">Display ausschalten (Shizuku optional)</string>
-    <string name="screen_admin_required">Geräteadministrator-Berechtigung erforderlich</string>
     <string name="category_haptic">Haptisches Feedback</string>
     <string name="haptic_title">Haptisches Feedback</string>
     <string name="haptic_description">Vibrieren bei Verwendung von Timer und Bedienelementen</string>
@@ -60,6 +59,17 @@
     <string name="shizuku_feature_wifi">WLAN nach Timer-Ende auszuschalten erfordert Shizuku, da moderne Android-Versionen Apps das direkte Umschalten von WLAN verbieten.</string>
     <string name="shizuku_feature_bluetooth">Bluetooth nach Timer-Ende auszuschalten erfordert Shizuku, da moderne Android-Versionen Apps das direkte Umschalten von Bluetooth verbieten.</string>
 
+    <!-- Kurzbezeichnungen für die Bullet-Liste im Startup-Dialog -->
+    <string name="shizuku_feature_label_display">Display ausschalten</string>
+    <string name="shizuku_feature_label_wifi">WLAN ausschalten</string>
+    <string name="shizuku_feature_label_bluetooth">Bluetooth ausschalten</string>
+    <string name="shizuku_startup_intro">Die Shizuku-Berechtigung fehlt für folgende aktivierte Funktionen:</string>
+
+    <!-- Geräteadministrator-Dialog (beim Start) -->
+    <string name="admin_dialog_title">Geräteadministrator erforderlich</string>
+    <string name="admin_body_required">Die Geräteadministrator-Berechtigung fehlt. Ohne sie kann SleepTimer den Bildschirm nicht sperren, wenn der Timer endet.</string>
+    <string name="admin_action_grant">Berechtigung erteilen</string>
+
     <!-- Shizuku-Funktionen -->
     <string name="wifi_off_title">WLAN ausschalten</string>
     <string name="wifi_off_description">WLAN deaktivieren (Shizuku benötigt)</string>
@@ -72,8 +82,8 @@
     <string name="screen_method_hard_description">Standard-Android-Sperre. Code zum Entsperren nötig.</string>
     <string name="screen_method_soft_title">Shizuku (sanft)</string>
     <string name="screen_method_soft_description">Simuliert Power-Taste. Biometrische Entsperrung bleibt aktiv.</string>
-    <string name="screen_method_active_hard">Geräteadministrator — Code zum Entsperren nötig</string>
-    <string name="screen_method_active_soft">Shizuku — biometrische Entsperrung bleibt aktiv</string>
+    <string name="screen_method_active_hard">Display ausschalten - Geräteadministrator</string>
+    <string name="screen_method_active_soft">Display ausschalten - Shizuku</string>
 
     <!-- Über die App -->
     <string name="category_about">Über</string>

--- a/feature/timer/src/main/res/values-de/strings.xml
+++ b/feature/timer/src/main/res/values-de/strings.xml
@@ -66,9 +66,12 @@
     <string name="shizuku_startup_intro">Die Shizuku-Berechtigung fehlt für folgende aktivierte Funktionen:</string>
 
     <!-- Geräteadministrator-Dialog (beim Start) -->
-    <string name="admin_dialog_title">Geräteadministrator erforderlich</string>
+    <string name="admin_dialog_title">Geräteadministrator-Berechtigung erforderlich</string>
     <string name="admin_body_required">Die Geräteadministrator-Berechtigung fehlt. Ohne sie kann SleepTimer den Bildschirm nicht sperren, wenn der Timer endet.</string>
     <string name="admin_action_grant">Berechtigung erteilen</string>
+
+    <!-- Generischer Dialog-Action für Startup-Berechtigungswarnungen -->
+    <string name="dialog_action_ignore">Ignorieren</string>
 
     <!-- Shizuku-Funktionen -->
     <string name="wifi_off_title">WLAN ausschalten</string>

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -30,7 +30,6 @@
     <string name="step_minutes_value">%d min</string>
     <string name="screen_title">Screen</string>
     <string name="screen_description">Lock screen when timer ends (Shizuku optional)</string>
-    <string name="screen_admin_required">Device admin permission required</string>
     <string name="category_haptic">Haptic Feedback</string>
     <string name="haptic_title">Haptic feedback</string>
     <string name="haptic_description">Vibrate when using timer and controls</string>
@@ -60,6 +59,17 @@
     <string name="shizuku_feature_wifi">Turning off Wi-Fi after the timer ends requires Shizuku because modern Android versions block apps from toggling Wi-Fi directly.</string>
     <string name="shizuku_feature_bluetooth">Turning off Bluetooth after the timer ends requires Shizuku because modern Android versions block apps from toggling Bluetooth directly.</string>
 
+    <!-- Short feature labels used in the startup permission dialog's bullet list -->
+    <string name="shizuku_feature_label_display">Turn off display</string>
+    <string name="shizuku_feature_label_wifi">Turn off Wi-Fi</string>
+    <string name="shizuku_feature_label_bluetooth">Turn off Bluetooth</string>
+    <string name="shizuku_startup_intro">Shizuku permission is missing for the following enabled features:</string>
+
+    <!-- Device admin required dialog (startup) -->
+    <string name="admin_dialog_title">Device admin required</string>
+    <string name="admin_body_required">Device admin permission is missing. Without it SleepTimer cannot lock the screen when the timer ends.</string>
+    <string name="admin_action_grant">Grant permission</string>
+
     <!-- Shizuku feature toggles -->
     <string name="wifi_off_title">Turn off Wi-Fi</string>
     <string name="wifi_off_description">Disable Wi-Fi when timer ends (requires Shizuku)</string>
@@ -72,8 +82,8 @@
     <string name="screen_method_hard_description">Standard Android lock. Requires credential to unlock.</string>
     <string name="screen_method_soft_title">Shizuku (soft)</string>
     <string name="screen_method_soft_description">Simulates power button. Biometric unlock stays active.</string>
-    <string name="screen_method_active_hard">Device admin — credential required to unlock</string>
-    <string name="screen_method_active_soft">Shizuku — biometric unlock stays active</string>
+    <string name="screen_method_active_hard">Turn off display - Device admin</string>
+    <string name="screen_method_active_soft">Turn off display - Shizuku</string>
 
     <!-- About -->
     <string name="category_about">About</string>

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -66,9 +66,12 @@
     <string name="shizuku_startup_intro">Shizuku permission is missing for the following enabled features:</string>
 
     <!-- Device admin required dialog (startup) -->
-    <string name="admin_dialog_title">Device admin required</string>
+    <string name="admin_dialog_title">Device admin permission required</string>
     <string name="admin_body_required">Device admin permission is missing. Without it SleepTimer cannot lock the screen when the timer ends.</string>
     <string name="admin_action_grant">Grant permission</string>
+
+    <!-- Generic dialog action used for startup permission warnings -->
+    <string name="dialog_action_ignore">Ignore</string>
 
     <!-- Shizuku feature toggles -->
     <string name="wifi_off_title">Turn off Wi-Fi</string>


### PR DESCRIPTION
## Summary
Recovers 4 commits that were merged into the `feat/in-app-rotation` branch (via PR #24) instead of into `main`. PR #23 then merged an earlier snapshot of `feat/in-app-rotation` into `main`, leaving these commits stranded on the remote branch. This restores:

- Simplified Screen toggle description (`Turn off display – Device admin` / `– Shizuku`) — the visible text change that first made this regression noticeable
- Startup permission-prompt dialogs (device admin + Shizuku) with Material 3 styling
- Shizuku binder-ready wait before running the startup check

## Recovered commits (cherry-picked from `origin/feat/in-app-rotation`)
- `0229088` feat(screen-off): prompt for missing permissions on startup
- `828b939` style(dialogs): align with Material 3 guidelines
- `98c370c` style(dialogs): use Ignore on startup prompts, clarify admin title
- `533fc49` fix(shizuku): wait for binder before running startup check

One conflict in `TimerViewModel.kt` (imports + placement of new startup-check functions vs. the `commitMinutes` refactor from `feat/dial-adjust-while-running`) resolved by keeping both sides.

## Test plan
- [x] `./gradlew assembleDebug` — green
- [ ] Settings → Screen toggle shows the new short description
- [ ] Fresh launch with screen-off enabled but device admin revoked → admin dialog appears
- [ ] Fresh launch with Shizuku features enabled but Shizuku not ready → Shizuku dialog appears, no NotRunning flash from binder race
- [ ] Cancel on dialog leaves toggles untouched; dialog returns on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)