### PR TITLE
feat(icon): replace launcher icon with night-sky moon-clock design

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,17 +1,75 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Adaptive icon foreground. Source: docs/icon/sleep_timer_icon_foreground.svg
+  Original 680x680 artwork is scaled into the inner 72x72 safe zone of the
+  108x108 adaptive-icon viewport via translate(18,18) scale(72/680).
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
     android:height="108dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
     <group
-        android:translateX="22"
-        android:translateY="22">
+        android:translateX="18"
+        android:translateY="18"
+        android:scaleX="0.10588"
+        android:scaleY="0.10588">
+
         <path
-            android:fillColor="#FFFFFF"
-            android:pathData="M32,4C16.54,4 4,16.54 4,32s12.54,28 27.99,28C47.46,60 60,47.46 60,32S47.46,4 32,4zM32,56c-13.26,0 -24,-10.74 -24,-24s10.74,-24 24,-24 24,10.74 24,24 -10.74,24 -24,24z" />
+            android:fillColor="#F7E8A8"
+            android:pathData="M205,225 a135,135 0 1 0 270,0 a135,135 0 1 0 -270,0 Z" />
         <path
-            android:fillColor="#FFFFFF"
-            android:pathData="M33.5,18H30v18l15.75,9.45 2.25,-3.69 -13.5,-8.01z" />
+            android:fillColor="#1C2A5E"
+            android:fillAlpha="0.14"
+            android:pathData="M285,190 a120,120 0 1 0 240,0 a120,120 0 1 0 -240,0 Z" />
+
+        <path
+            android:fillColor="#2D3A70"
+            android:pathData="M335,120 a5,5 0 1 0 10,0 a5,5 0 1 0 -10,0 Z" />
+        <path
+            android:fillColor="#2D3A70"
+            android:pathData="M440,225 a5,5 0 1 0 10,0 a5,5 0 1 0 -10,0 Z" />
+        <path
+            android:fillColor="#2D3A70"
+            android:pathData="M335,330 a5,5 0 1 0 10,0 a5,5 0 1 0 -10,0 Z" />
+        <path
+            android:fillColor="#2D3A70"
+            android:pathData="M230,225 a5,5 0 1 0 10,0 a5,5 0 1 0 -10,0 Z" />
+
+        <path
+            android:strokeColor="#2D3A70"
+            android:strokeWidth="9"
+            android:strokeLineCap="round"
+            android:pathData="M340,225 L340,135" />
+        <path
+            android:strokeColor="#2D3A70"
+            android:strokeWidth="11"
+            android:strokeLineCap="round"
+            android:pathData="M340,225 L278,178" />
+        <path
+            android:fillColor="#2D3A70"
+            android:pathData="M330,225 a10,10 0 1 0 20,0 a10,10 0 1 0 -20,0 Z" />
+
+        <path
+            android:fillColor="#F7E8A8"
+            android:pathData="M119,400 H141 a14,14 0 0 1 14,14 V581 a14,14 0 0 1 -14,14 H119 a14,14 0 0 1 -14,-14 V414 a14,14 0 0 1 14,-14 Z" />
+        <path
+            android:fillColor="#F7E8A8"
+            android:pathData="M125,490 H555 a20,20 0 0 1 20,20 V570 a20,20 0 0 1 -20,20 H125 a20,20 0 0 1 -20,-20 V510 a20,20 0 0 1 20,-20 Z" />
+        <path
+            android:fillColor="#FFF4C8"
+            android:pathData="M172,462 H288 a12,12 0 0 1 12,12 V498 a12,12 0 0 1 -12,12 H172 a12,12 0 0 1 -12,-12 V474 a12,12 0 0 1 12,-12 Z" />
+        <path
+            android:fillColor="#C9B87E"
+            android:pathData="M310,493 h265 v7 h-265 z" />
+        <path
+            android:fillColor="#F7E8A8"
+            android:pathData="M567,455 H578 a12,12 0 0 1 12,12 V583 a12,12 0 0 1 -12,12 H567 a12,12 0 0 1 -12,-12 V467 a12,12 0 0 1 12,-12 Z" />
+        <path
+            android:fillColor="#F7E8A8"
+            android:pathData="M118,595 H132 a3,3 0 0 1 3,3 V614 a3,3 0 0 1 -3,3 H118 a3,3 0 0 1 -3,-3 V598 a3,3 0 0 1 3,-3 Z" />
+        <path
+            android:fillColor="#F7E8A8"
+            android:pathData="M563,595 H577 a3,3 0 0 1 3,3 V614 a3,3 0 0 1 -3,3 H563 a3,3 0 0 1 -3,-3 V598 a3,3 0 0 1 3,-3 Z" />
     </group>
 </vector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#5B5FE6</color>
+    <color name="ic_launcher_background">#1C2A5E</color>
     <color name="midnight_bg">#1A1830</color>
 </resources>

--- a/docs/icon/sleep_timer_icon.svg
+++ b/docs/icon/sleep_timer_icon.svg
@@ -1,0 +1,39 @@
+<svg width="1024" height="1024" viewBox="0 0 680 680" xmlns="http://www.w3.org/2000/svg">
+  <title>Sleep timer app icon</title>
+  <desc>Mond-Uhr-Kombination ueber einem Bett auf dunklem Nachthimmel-Hintergrund</desc>
+
+  <!-- Hintergrund: abgerundetes Quadrat, Nachthimmel -->
+  <rect width="680" height="680" rx="140" fill="#1c2a5e"/>
+
+  <!-- Sterne -->
+  <circle cx="110" cy="155" r="5" fill="#f7e8a8"/>
+  <circle cx="145" cy="95" r="3" fill="#f7e8a8"/>
+  <circle cx="565" cy="130" r="5" fill="#f7e8a8"/>
+  <circle cx="610" cy="255" r="3" fill="#f7e8a8"/>
+  <circle cx="75" cy="305" r="3" fill="#f7e8a8"/>
+  <circle cx="605" cy="410" r="4" fill="#f7e8a8"/>
+
+  <!-- Mond/Uhr: Vollkreis mit Crescent-Schatten -->
+  <circle cx="340" cy="225" r="135" fill="#f7e8a8"/>
+  <circle cx="405" cy="190" r="120" fill="#1c2a5e" opacity="0.14"/>
+
+  <!-- Stundenmarkierungen (12, 3, 6, 9) -->
+  <circle cx="340" cy="120" r="5" fill="#2d3a70"/>
+  <circle cx="445" cy="225" r="5" fill="#2d3a70"/>
+  <circle cx="340" cy="330" r="5" fill="#2d3a70"/>
+  <circle cx="235" cy="225" r="5" fill="#2d3a70"/>
+
+  <!-- Uhrzeiger: Minutenzeiger auf 12, Stundenzeiger auf 10 -->
+  <line x1="340" y1="225" x2="340" y2="135" stroke="#2d3a70" stroke-width="9" stroke-linecap="round"/>
+  <line x1="340" y1="225" x2="278" y2="178" stroke="#2d3a70" stroke-width="11" stroke-linecap="round"/>
+  <circle cx="340" cy="225" r="10" fill="#2d3a70"/>
+
+  <!-- Bett -->
+  <rect x="105" y="400" width="50" height="195" rx="14" fill="#f7e8a8"/>
+  <rect x="105" y="490" width="470" height="100" rx="20" fill="#f7e8a8"/>
+  <rect x="160" y="462" width="140" height="48" rx="12" fill="#fff4c8"/>
+  <rect x="310" y="493" width="265" height="7" fill="#c9b87e"/>
+  <rect x="555" y="455" width="35" height="140" rx="12" fill="#f7e8a8"/>
+  <rect x="115" y="595" width="20" height="22" rx="3" fill="#f7e8a8"/>
+  <rect x="560" y="595" width="20" height="22" rx="3" fill="#f7e8a8"/>
+</svg>

--- a/docs/icon/sleep_timer_icon_foreground.svg
+++ b/docs/icon/sleep_timer_icon_foreground.svg
@@ -1,0 +1,33 @@
+<svg width="1024" height="1024" viewBox="0 0 108 108" xmlns="http://www.w3.org/2000/svg">
+  <title>Sleep timer app icon - foreground</title>
+  <desc>Foreground-Layer fuer Android adaptive icon, Content im zentralen 72x72 Safe-Bereich</desc>
+
+  <!-- Content skaliert von 680x680 auf 72x72 und zentriert in 108x108 Viewport (Safe Zone) -->
+  <g transform="translate(18 18) scale(0.10588)">
+
+    <!-- Mond/Uhr: Vollkreis mit Crescent-Schatten -->
+    <circle cx="340" cy="225" r="135" fill="#f7e8a8"/>
+    <circle cx="405" cy="190" r="120" fill="#1c2a5e" opacity="0.14"/>
+
+    <!-- Stundenmarkierungen -->
+    <circle cx="340" cy="120" r="5" fill="#2d3a70"/>
+    <circle cx="445" cy="225" r="5" fill="#2d3a70"/>
+    <circle cx="340" cy="330" r="5" fill="#2d3a70"/>
+    <circle cx="235" cy="225" r="5" fill="#2d3a70"/>
+
+    <!-- Uhrzeiger -->
+    <line x1="340" y1="225" x2="340" y2="135" stroke="#2d3a70" stroke-width="9" stroke-linecap="round"/>
+    <line x1="340" y1="225" x2="278" y2="178" stroke="#2d3a70" stroke-width="11" stroke-linecap="round"/>
+    <circle cx="340" cy="225" r="10" fill="#2d3a70"/>
+
+    <!-- Bett -->
+    <rect x="105" y="400" width="50" height="195" rx="14" fill="#f7e8a8"/>
+    <rect x="105" y="490" width="470" height="100" rx="20" fill="#f7e8a8"/>
+    <rect x="160" y="462" width="140" height="48" rx="12" fill="#fff4c8"/>
+    <rect x="310" y="493" width="265" height="7" fill="#c9b87e"/>
+    <rect x="555" y="455" width="35" height="140" rx="12" fill="#f7e8a8"/>
+    <rect x="115" y="595" width="20" height="22" rx="3" fill="#f7e8a8"/>
+    <rect x="560" y="595" width="20" height="22" rx="3" fill="#f7e8a8"/>
+
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Replaces the stock Android Studio clock vector with a custom adaptive-icon foreground (moon-clock above a bed) sized to the 72x72 safe zone of the 108x108 viewport.
- Updates `ic_launcher_background` from the stock purple `#5B5FE6` to the matching night-sky `#1C2A5E`.
- Lands the source SVGs under `docs/icon/` so the icon can be re-rendered for store listings later.

The legacy mipmap PNGs are intentionally not added: `minSdk = 26` means every supported device renders the adaptive icon directly.

## Test plan
- [x] `./gradlew :app:assembleDebug` succeeds (vector drawable parses).
- [ ] Install on a device (`./gradlew installDebug`) and confirm the launcher icon renders correctly under the standard mask shapes (circle, squircle, rounded square).
- [ ] Confirm icon size/positioning in the launcher feels right; adjust the foreground `scale` factor if the motif looks too small or too large.

🤖 Generated with [Claude Code](https://claude.com/claude-code)