### PR TITLE
fix(fdroid): strip Play dependency-metadata block from APK, bump to 1.1.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,14 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
+    dependenciesInfo {
+        // AGP embeds a Play-encrypted dependency list in the APK signing block by default.
+        // F-Droid's scanner rejects that opaque blob ("extra signing block 'Dependency
+        // metadata'"), and nothing but Google Play can read it — drop it entirely.
+        includeInApk = false
+        includeInBundle = false
+    }
+
     packaging {
         jniLibs {
             // Package the DataStore native libs as shipped in the dependency instead of

--- a/app/version.properties
+++ b/app/version.properties
@@ -1,5 +1,5 @@
 # Read by F-Droid checkupdates (UpdateCheckData in fdroiddata's metadata/dev.xitee.sleeptimer.yml).
 # NOT used by the Gradle build — axion-release derives the real values from the git tag.
 # Bump in the release commit so these values match the tag about to be created.
-versionName=1.1.1
-versionCode=101010
+versionName=1.1.2
+versionCode=101020

--- a/fastlane/metadata/android/de-DE/changelogs/101020.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/101020.txt
@@ -1,0 +1,1 @@
+* Intern: Google-Play-Abhängigkeits-Metadatenblock aus dem APK entfernt (Voraussetzung für die F-Droid-Aufnahme). Keine sichtbaren Änderungen.

--- a/fastlane/metadata/android/en-US/changelogs/101020.txt
+++ b/fastlane/metadata/android/en-US/changelogs/101020.txt
@@ -1,0 +1,1 @@
+* Internal: removed the Google Play dependency-metadata block from the APK (required for F-Droid inclusion). No user-facing changes.


### PR DESCRIPTION
F-Droid's `check apk` CI job rejected the v1.1.1 release APK: AGP embeds a Google-Play-encrypted dependency list as an extra APK signing block by default (`Dependency metadata`), which F-Droid treats as an opaque non-transparent blob.

- Disable it via `dependenciesInfo { includeInApk = false; includeInBundle = false }`
- Bump `version.properties` to 1.1.2 / 101020 and add the matching fastlane changelogs (en-US + de-DE)

After merging, tag `v1.1.2` — the fdroiddata recipe will point at that release instead of v1.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)