### PR TITLE
docs: add F-Droid download badge, drop "submission pending"

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ network.
 
 ### F-Droid
 
-_Submission pending._
+SleepTimer is available on [F-Droid](https://f-droid.org/packages/dev.xitee.sleeptimer/):
+
+[<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="80">](https://f-droid.org/packages/dev.xitee.sleeptimer/)
 
 ### GitHub Releases
 


### PR DESCRIPTION
## Summary

SleepTimer is now published and live on F-Droid at [`dev.xitee.sleeptimer`](https://f-droid.org/packages/dev.xitee.sleeptimer/). This updates the README Installation section accordingly:

- Removes the `_Submission pending._` placeholder under the **F-Droid** heading.
- Adds the official "Get it on F-Droid" badge linking to the package page.

## Verification

- `https://f-droid.org/packages/dev.xitee.sleeptimer/` returns HTTP 200 (page is live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)