### PR TITLE
feat(timer): add choice between pausing and stopping media on expiry

### DIFF
--- a/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/model/MediaEndAction.kt
+++ b/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/model/MediaEndAction.kt
@@ -1,0 +1,14 @@
+package dev.xitee.sleeptimer.core.data.model
+
+enum class MediaEndAction {
+    Pause,
+    Stop,
+    ;
+
+    companion object {
+        val Default: MediaEndAction = Pause
+
+        fun fromStorage(value: String?): MediaEndAction =
+            entries.firstOrNull { it.name == value } ?: Default
+    }
+}

--- a/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/model/UserSettings.kt
+++ b/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/model/UserSettings.kt
@@ -2,6 +2,7 @@ package dev.xitee.sleeptimer.core.data.model
 
 data class UserSettings(
     val stopMediaPlayback: Boolean = true,
+    val mediaEndAction: MediaEndAction = MediaEndAction.Default,
     val fadeOutDurationSeconds: Int = 30,
     val screenOff: Boolean = false,
     val softScreenOff: Boolean = false,

--- a/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/repository/SettingsRepository.kt
+++ b/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/repository/SettingsRepository.kt
@@ -1,6 +1,7 @@
 package dev.xitee.sleeptimer.core.data.repository
 
 import dev.xitee.sleeptimer.core.data.model.AutoRotateMode
+import dev.xitee.sleeptimer.core.data.model.MediaEndAction
 import dev.xitee.sleeptimer.core.data.model.ThemeId
 import dev.xitee.sleeptimer.core.data.model.UserSettings
 import kotlinx.coroutines.flow.Flow
@@ -8,6 +9,7 @@ import kotlinx.coroutines.flow.Flow
 interface SettingsRepository {
     val settings: Flow<UserSettings>
     suspend fun updateStopMediaPlayback(enabled: Boolean)
+    suspend fun updateMediaEndAction(action: MediaEndAction)
     suspend fun updateFadeOutDuration(seconds: Int)
     suspend fun updateScreenOff(enabled: Boolean)
     suspend fun updateSoftScreenOff(enabled: Boolean)

--- a/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/repository/SettingsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/dev/xitee/sleeptimer/core/data/repository/SettingsRepositoryImpl.kt
@@ -11,6 +11,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.xitee.sleeptimer.core.data.model.AutoRotateMode
 import dev.xitee.sleeptimer.core.data.model.MAX_TIMER_MINUTES
+import dev.xitee.sleeptimer.core.data.model.MediaEndAction
 import dev.xitee.sleeptimer.core.data.model.ThemeId
 import dev.xitee.sleeptimer.core.data.model.UserSettings
 import dev.xitee.sleeptimer.core.data.util.isSystemReduceMotionEnabled
@@ -34,6 +35,7 @@ class SettingsRepositoryImpl @Inject constructor(
 
     private companion object {
         val STOP_MEDIA = booleanPreferencesKey("stop_media_playback")
+        val MEDIA_END_ACTION = stringPreferencesKey("media_end_action")
         val FADE_OUT_DURATION = intPreferencesKey("fade_out_duration_seconds")
         val SCREEN_OFF = booleanPreferencesKey("screen_off")
         val SOFT_SCREEN_OFF = booleanPreferencesKey("soft_screen_off")
@@ -87,6 +89,7 @@ class SettingsRepositoryImpl @Inject constructor(
         val d = UserSettings()
         UserSettings(
             stopMediaPlayback = prefs[STOP_MEDIA] ?: d.stopMediaPlayback,
+            mediaEndAction = MediaEndAction.fromStorage(prefs[MEDIA_END_ACTION]),
             fadeOutDurationSeconds = prefs[FADE_OUT_DURATION] ?: d.fadeOutDurationSeconds,
             screenOff = prefs[SCREEN_OFF] ?: d.screenOff,
             softScreenOff = prefs[SOFT_SCREEN_OFF] ?: d.softScreenOff,
@@ -106,6 +109,10 @@ class SettingsRepositoryImpl @Inject constructor(
 
     override suspend fun updateStopMediaPlayback(enabled: Boolean) {
         dataStore.edit { it[STOP_MEDIA] = enabled }
+    }
+
+    override suspend fun updateMediaEndAction(action: MediaEndAction) {
+        dataStore.edit { it[MEDIA_END_ACTION] = action.name }
     }
 
     override suspend fun updateFadeOutDuration(seconds: Int) {

--- a/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/SleepTimerService.kt
+++ b/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/SleepTimerService.kt
@@ -292,7 +292,10 @@ class SleepTimerService : Service() {
             updateTimerState(TimerPhase.FADING_OUT)
             lastNotifiedMinutes = Int.MIN_VALUE
             notificationManager.updateNotification(0, stepMinutes, TimerPhase.FADING_OUT)
-            mediaVolumeController.fadeOutAndPause(settings.fadeOutDurationSeconds)
+            mediaVolumeController.fadeOutAndEndPlayback(
+                settings.fadeOutDurationSeconds,
+                settings.mediaEndAction,
+            )
         }
 
         if (settings.turnOffWifi && shizukuManager.isReady()) {

--- a/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/media/MediaVolumeController.kt
+++ b/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/media/MediaVolumeController.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.media.AudioManager
 import android.view.KeyEvent
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.xitee.sleeptimer.core.data.model.MediaEndAction
 import kotlinx.coroutines.delay
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,11 +16,11 @@ class MediaVolumeController @Inject constructor(
     private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     private var originalVolume: Int = -1
 
-    suspend fun fadeOutAndPause(durationSeconds: Int) {
+    suspend fun fadeOutAndEndPlayback(durationSeconds: Int, endAction: MediaEndAction) {
         originalVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
 
         if (originalVolume <= 0 || durationSeconds <= 0) {
-            pauseMedia()
+            endPlayback(endAction)
             return
         }
 
@@ -31,7 +32,7 @@ class MediaVolumeController @Inject constructor(
             delay(intervalMs)
         }
 
-        pauseMedia()
+        endPlayback(endAction)
         restoreVolume()
     }
 
@@ -53,11 +54,13 @@ class MediaVolumeController @Inject constructor(
         originalVolume = -1
     }
 
-    fun pauseMedia() {
-        val downEvent = KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MEDIA_PAUSE)
-        val upEvent = KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MEDIA_PAUSE)
-        audioManager.dispatchMediaKeyEvent(downEvent)
-        audioManager.dispatchMediaKeyEvent(upEvent)
+    private fun endPlayback(action: MediaEndAction) {
+        val keyCode = when (action) {
+            MediaEndAction.Pause -> KeyEvent.KEYCODE_MEDIA_PAUSE
+            MediaEndAction.Stop -> KeyEvent.KEYCODE_MEDIA_STOP
+        }
+        audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, keyCode))
+        audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyCode))
     }
 
     fun restoreVolume() {

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.MusicOff
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.RocketLaunch
 import androidx.compose.material.icons.filled.ScreenRotation
+import androidx.compose.material.icons.filled.StopCircle
 import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material3.Icon
@@ -58,6 +59,7 @@ import dev.xitee.sleeptimer.core.data.model.AutoRotateMode
 import dev.xitee.sleeptimer.feature.timer.R
 import dev.xitee.sleeptimer.feature.timer.settings.components.AutoRotateModeDialog
 import dev.xitee.sleeptimer.feature.timer.settings.components.FadeOutSlider
+import dev.xitee.sleeptimer.feature.timer.settings.components.MediaEndActionDialog
 import dev.xitee.sleeptimer.feature.timer.settings.components.ScreenLockMethodDialog
 import dev.xitee.sleeptimer.feature.timer.settings.components.labelRes
 import dev.xitee.sleeptimer.feature.timer.settings.components.SettingsToggleRow
@@ -120,6 +122,7 @@ private fun SettingsContent(
     var pendingShizukuToggle by remember { mutableStateOf<(() -> Unit)?>(null) }
     var showMethodDialog by remember { mutableStateOf(false) }
     var showAutoRotateDialog by remember { mutableStateOf(false) }
+    var showMediaEndActionDialog by remember { mutableStateOf(false) }
 
     fun requestWithShizuku(explanation: String, enableAction: () -> Unit) {
         if (viewModel.isShizukuReady()) {
@@ -177,6 +180,14 @@ private fun SettingsContent(
             selected = uiState.settings.autoRotateMode,
             onSelect = { viewModel.updateAutoRotateMode(it) },
             onDismiss = { showAutoRotateDialog = false },
+        )
+    }
+
+    if (showMediaEndActionDialog) {
+        MediaEndActionDialog(
+            selected = uiState.settings.mediaEndAction,
+            onSelect = { viewModel.updateMediaEndAction(it) },
+            onDismiss = { showMediaEndActionDialog = false },
         )
     }
 
@@ -258,6 +269,12 @@ private fun SettingsContent(
                     description = stringResource(R.string.playback_description),
                     checked = uiState.settings.stopMediaPlayback,
                     onCheckedChange = { viewModel.updateStopMediaPlayback(it) },
+                )
+                SettingsNavigationRow(
+                    icon = Icons.Default.StopCircle,
+                    title = stringResource(R.string.media_end_action_title),
+                    description = stringResource(uiState.settings.mediaEndAction.labelRes),
+                    onClick = { showMediaEndActionDialog = true },
                 )
                 FadeOutSlider(
                     durationSeconds = uiState.settings.fadeOutDurationSeconds,

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.xitee.sleeptimer.core.data.model.AutoRotateMode
+import dev.xitee.sleeptimer.core.data.model.MediaEndAction
 import dev.xitee.sleeptimer.core.data.model.ThemeId
 import dev.xitee.sleeptimer.core.data.repository.SettingsRepository
 import dev.xitee.sleeptimer.core.service.screen.ScreenLockHelper
@@ -58,6 +59,10 @@ class SettingsViewModel @Inject constructor(
 
     fun updateStopMediaPlayback(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.updateStopMediaPlayback(enabled) }
+    }
+
+    fun updateMediaEndAction(action: MediaEndAction) {
+        viewModelScope.launch { settingsRepository.updateMediaEndAction(action) }
     }
 
     fun updateFadeOutDuration(seconds: Int) {

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/MediaEndActionDialog.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/components/MediaEndActionDialog.kt
@@ -1,0 +1,113 @@
+package dev.xitee.sleeptimer.feature.timer.settings.components
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MusicOff
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import dev.xitee.sleeptimer.core.data.model.MediaEndAction
+import dev.xitee.sleeptimer.feature.timer.R
+import dev.xitee.sleeptimer.feature.timer.theme.appTheme
+
+/** Title string shown in the settings row's description slot for the selected action. */
+@get:StringRes
+val MediaEndAction.labelRes: Int
+    get() = when (this) {
+        MediaEndAction.Pause -> R.string.media_end_action_pause_title
+        MediaEndAction.Stop -> R.string.media_end_action_stop_title
+    }
+
+@Composable
+fun MediaEndActionDialog(
+    selected: MediaEndAction,
+    onSelect: (MediaEndAction) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.MusicOff, contentDescription = null) },
+        title = { Text(stringResource(R.string.media_end_action_dialog_title)) },
+        text = {
+            Column {
+                ActionOption(
+                    icon = Icons.Default.Pause,
+                    title = stringResource(R.string.media_end_action_pause_title),
+                    description = stringResource(R.string.media_end_action_pause_description),
+                    isSelected = selected == MediaEndAction.Pause,
+                    onClick = { onSelect(MediaEndAction.Pause); onDismiss() },
+                )
+                Spacer(Modifier.height(8.dp))
+                ActionOption(
+                    icon = Icons.Default.Stop,
+                    title = stringResource(R.string.media_end_action_stop_title),
+                    description = stringResource(R.string.media_end_action_stop_description),
+                    isSelected = selected == MediaEndAction.Stop,
+                    onClick = { onSelect(MediaEndAction.Stop); onDismiss() },
+                )
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.shizuku_action_cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun ActionOption(
+    icon: ImageVector,
+    title: String,
+    description: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    val accent = appTheme().accent
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            tint = if (isSelected) accent else LocalContentColor.current,
+            modifier = Modifier.size(28.dp),
+        )
+        Spacer(Modifier.width(16.dp))
+        Column {
+            Text(
+                title,
+                style = MaterialTheme.typography.titleMedium,
+                color = if (isSelected) accent else LocalContentColor.current,
+                fontWeight = if (isSelected) FontWeight.SemiBold else null,
+            )
+            Text(description, style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}

--- a/feature/timer/src/main/res/values-de/strings.xml
+++ b/feature/timer/src/main/res/values-de/strings.xml
@@ -34,6 +34,12 @@
     <string name="category_sleep_timer">Sleep Timer</string>
     <string name="playback_title">Wiedergabe</string>
     <string name="playback_description">Medienwiedergabe stoppen</string>
+    <string name="media_end_action_title">Pausieren oder stoppen</string>
+    <string name="media_end_action_dialog_title">Aktion nach Ablauf wählen</string>
+    <string name="media_end_action_pause_title">Pausieren</string>
+    <string name="media_end_action_pause_description">Wiedergabe kann an derselben Stelle fortgesetzt werden</string>
+    <string name="media_end_action_stop_title">Stoppen</string>
+    <string name="media_end_action_stop_description">Wiedergabesitzung vollständig beenden</string>
     <string name="fade_out_title">Fade-out-Dauer</string>
     <string name="fade_out_seconds">%d Sekunden</string>
     <string name="step_minutes_title">+/− Schrittweite</string>

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -34,6 +34,12 @@
     <string name="category_sleep_timer">Sleep Timer</string>
     <string name="playback_title">Playback</string>
     <string name="playback_description">Stop audio and video playback</string>
+    <string name="media_end_action_title">Pause or stop</string>
+    <string name="media_end_action_dialog_title">Choose end action</string>
+    <string name="media_end_action_pause_title">Pause</string>
+    <string name="media_end_action_pause_description">Playback can be resumed where it left off</string>
+    <string name="media_end_action_stop_title">Stop</string>
+    <string name="media_end_action_stop_description">End the playback session completely</string>
     <string name="fade_out_title">Fade-out duration</string>
     <string name="fade_out_seconds">%d seconds</string>
     <string name="step_minutes_title">+/− step</string>


### PR DESCRIPTION
## Summary

Adds a setting to choose what happens to media playback when the timer expires: **Pause** (the previous, still-default behavior) or **Stop**.

- New `MediaEndAction` enum (`Pause`/`Stop`) in `core:data`, persisted via DataStore as `media_end_action`, defaulting to `Pause` so existing users see no behavior change.
- `MediaVolumeController.fadeOutAndPause` → `fadeOutAndEndPlayback(durationSeconds, endAction)`: after the fade-out it dispatches `KEYCODE_MEDIA_PAUSE` or `KEYCODE_MEDIA_STOP` depending on the setting. The fade logic itself is unchanged.
- Settings UI: a "Pause or stop" picker row directly under the Playback toggle, showing the current selection in the description slot and opening a two-option dialog — same pattern as the auto-rotate mode picker. Strings added in `en` and `de`.

Note on semantics: `KEYCODE_MEDIA_STOP` is delivered to the active media session like pause, but its interpretation is player-dependent — most apps end the session and dismiss their media notification; a few treat it identically to pause.

## Testing

- `./gradlew assembleDebug` — passes
- `./gradlew lint` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)