### PR TITLE
Add battery optimization exemption setting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Only used by the opt-in "Ignore battery optimization" settings row; never
+         requested automatically. Play policy concern (BatteryLife) doesn't apply —
+         the app ships via F-Droid/GitHub. -->
+    <uses-permission
+        android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"
+        tools:ignore="BatteryLife" />
 
     <!-- Required on targetSdk 30+ for PackageManager.getPackageInfo() to see Shizuku. -->
     <queries>

--- a/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/power/BatteryOptimizationHelper.kt
+++ b/core/service/src/main/kotlin/dev/xitee/sleeptimer/core/service/power/BatteryOptimizationHelper.kt
@@ -1,0 +1,46 @@
+package dev.xitee.sleeptimer.core.service.power
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.os.PowerManager
+import android.provider.Settings
+import androidx.core.net.toUri
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Queries and requests the battery-optimization exemption. Doze/App-Standby can
+ * defer or kill the foreground service on aggressive OEM builds, so the timer may
+ * silently stop mid-countdown; the exemption is optional because stock Android
+ * usually keeps a foreground service alive without it.
+ */
+@Singleton
+class BatteryOptimizationHelper @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val powerManager =
+        context.getSystemService(Context.POWER_SERVICE) as PowerManager
+
+    fun isIgnoringBatteryOptimizations(): Boolean =
+        powerManager.isIgnoringBatteryOptimizations(context.packageName)
+
+    /**
+     * System dialog asking to exempt this app. Play policy discourages this action
+     * (the BatteryLife lint check), but the app is distributed via F-Droid/GitHub
+     * and the request is only ever triggered from an opt-in settings row.
+     */
+    @SuppressLint("BatteryLife")
+    fun requestExemptionIntent(): Intent = Intent(
+        Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+        "package:${context.packageName}".toUri(),
+    )
+
+    /**
+     * The system's battery-optimization list. The exemption can't be revoked
+     * programmatically, so turning the setting off sends the user here.
+     */
+    fun batteryOptimizationSettingsIntent(): Intent =
+        Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+}

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsScreen.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.BatterySaver
 import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.MusicOff
@@ -116,6 +117,14 @@ private fun SettingsContent(
         }
     }
 
+    // Refresh on return from the exemption dialog / battery settings so the row
+    // flips as soon as the system state actually changed.
+    val batteryLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) {
+        viewModel.refreshSystemState()
+    }
+
     var shizukuDialogExplanation by remember { mutableStateOf<String?>(null) }
     var pendingShizukuToggle by remember { mutableStateOf<(() -> Unit)?>(null) }
     var showMethodDialog by remember { mutableStateOf(false) }
@@ -193,11 +202,11 @@ private fun SettingsContent(
         viewModel.refreshShizuku()
     }
 
-    // Device admin can be revoked from system Settings without any broadcast we're
-    // subscribed to — re-query on resume so the "Screen" row description reflects
-    // the current admin state if the user came back from Settings → Device admin.
+    // Device admin and the battery-optimization exemption can both change in system
+    // Settings without any broadcast we're subscribed to — re-query on resume so the
+    // affected rows reflect the current state when the user comes back.
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-        viewModel.refreshDeviceAdminState()
+        viewModel.refreshSystemState()
     }
 
     TimerBackground(
@@ -320,6 +329,32 @@ private fun SettingsContent(
                         } else {
                             viewModel.updateTurnOffBluetooth(false)
                         }
+                    },
+                )
+
+                SectionHeader(stringResource(R.string.category_system))
+                // Reflects live system state, not a persisted preference: the check
+                // is what the OS reports, and toggling only launches the matching
+                // system UI (exemption dialog on, optimization list off — Android
+                // offers no way to re-optimize programmatically). The row updates
+                // via refreshSystemState() once the user returns.
+                SettingsToggleRow(
+                    icon = Icons.Default.BatterySaver,
+                    title = stringResource(R.string.battery_optimization_title),
+                    description = if (uiState.isIgnoringBatteryOptimizations) {
+                        stringResource(R.string.battery_optimization_active)
+                    } else {
+                        stringResource(R.string.battery_optimization_description)
+                    },
+                    checked = uiState.isIgnoringBatteryOptimizations,
+                    onCheckedChange = { enabled ->
+                        batteryLauncher.launch(
+                            if (enabled) {
+                                viewModel.batteryExemptionRequestIntent()
+                            } else {
+                                viewModel.batteryOptimizationSettingsIntent()
+                            },
+                        )
                     },
                 )
 

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsUiState.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsUiState.kt
@@ -7,4 +7,5 @@ data class SettingsUiState(
     val settings: UserSettings = UserSettings(),
     val shizukuState: ShizukuManager.State = ShizukuManager.State.NotInstalled,
     val isDeviceAdminActive: Boolean = false,
+    val isIgnoringBatteryOptimizations: Boolean = false,
 )

--- a/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsViewModel.kt
+++ b/feature/timer/src/main/kotlin/dev/xitee/sleeptimer/feature/timer/settings/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.xitee.sleeptimer.core.data.model.AutoRotateMode
 import dev.xitee.sleeptimer.core.data.model.ThemeId
 import dev.xitee.sleeptimer.core.data.repository.SettingsRepository
+import dev.xitee.sleeptimer.core.service.power.BatteryOptimizationHelper
 import dev.xitee.sleeptimer.core.service.screen.ScreenLockHelper
 import dev.xitee.sleeptimer.core.service.shizuku.ShizukuManager
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,24 +23,27 @@ class SettingsViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository,
     private val shizukuManager: ShizukuManager,
     private val screenLockHelper: ScreenLockHelper,
+    private val batteryOptimizationHelper: BatteryOptimizationHelper,
 ) : ViewModel() {
 
-    // Tick to re-query isAdminActive. Admin grants can be revoked from system Settings
-    // without any callback into the app, so nothing else drives a refresh. Bumped from
-    // SettingsScreen on ON_RESUME so returning from Settings → Security → Device admin
+    // Tick to re-query system state we get no callback for: device-admin grants and
+    // the battery-optimization exemption can both change in system Settings behind
+    // our back. Bumped from SettingsScreen on ON_RESUME so returning from Settings
     // reflects the current state.
-    private val adminRefreshTicker = MutableStateFlow(0)
+    private val systemStateRefreshTicker = MutableStateFlow(0)
 
     val uiState: StateFlow<SettingsUiState?> =
         combine(
             settingsRepository.settings,
             shizukuManager.state,
-            adminRefreshTicker,
+            systemStateRefreshTicker,
         ) { settings, shizukuState, _ ->
             SettingsUiState(
                 settings = settings,
                 shizukuState = shizukuState,
                 isDeviceAdminActive = screenLockHelper.isAdminActive(),
+                isIgnoringBatteryOptimizations =
+                    batteryOptimizationHelper.isIgnoringBatteryOptimizations(),
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
@@ -49,10 +53,15 @@ class SettingsViewModel @Inject constructor(
 
     fun refreshShizuku() = shizukuManager.refresh()
 
-    /** Triggers a re-read of the device-admin active flag. */
-    fun refreshDeviceAdminState() {
-        adminRefreshTicker.value = adminRefreshTicker.value + 1
+    /** Triggers a re-read of the device-admin and battery-exemption flags. */
+    fun refreshSystemState() {
+        systemStateRefreshTicker.value = systemStateRefreshTicker.value + 1
     }
+
+    fun batteryExemptionRequestIntent() = batteryOptimizationHelper.requestExemptionIntent()
+
+    fun batteryOptimizationSettingsIntent() =
+        batteryOptimizationHelper.batteryOptimizationSettingsIntent()
     fun requestShizukuPermission() = shizukuManager.requestPermission()
     fun isShizukuReady(): Boolean = shizukuManager.isReady()
 

--- a/feature/timer/src/main/res/values-de/strings.xml
+++ b/feature/timer/src/main/res/values-de/strings.xml
@@ -47,6 +47,10 @@
     <string name="widget_fixed_duration_off">Dieses Widget startet mit der zuletzt verwendeten Zeit</string>
     <string name="widget_fixed_duration_on">Dieses Widget startet immer mit der unten eingestellten Dauer</string>
 
+    <string name="category_system">System</string>
+    <string name="battery_optimization_title">Akku-Optimierung ignorieren</string>
+    <string name="battery_optimization_description">Empfohlen, falls der Timer im Hintergrund nicht zuverlässig läuft. Nicht auf jedem Gerät nötig.</string>
+    <string name="battery_optimization_active">SleepTimer ist von der Akku-Optimierung ausgenommen</string>
     <string name="category_haptic">Haptisches Feedback</string>
     <string name="haptic_title">Haptisches Feedback</string>
     <string name="haptic_description">Vibrieren bei Verwendung von Timer und Bedienelementen</string>

--- a/feature/timer/src/main/res/values/strings.xml
+++ b/feature/timer/src/main/res/values/strings.xml
@@ -47,6 +47,10 @@
     <string name="widget_fixed_duration_off">This widget starts with the last used time</string>
     <string name="widget_fixed_duration_on">This widget always starts with the duration below</string>
 
+    <string name="category_system">System</string>
+    <string name="battery_optimization_title">Ignore battery optimization</string>
+    <string name="battery_optimization_description">Recommended if the timer stops working in the background. Not needed on every device.</string>
+    <string name="battery_optimization_active">SleepTimer is exempt from battery optimization</string>
     <string name="category_haptic">Haptic Feedback</string>
     <string name="haptic_title">Haptic feedback</string>
     <string name="haptic_description">Vibrate when using timer and controls</string>


### PR DESCRIPTION
## Summary
Adds an opt-in settings row to request exemption from battery optimization (Doze/App-Standby), which can defer or kill the foreground service on aggressive OEM builds and cause the timer to silently stop mid-countdown.

## Changes
- **New `BatteryOptimizationHelper`** (`core:service`): Singleton that queries the battery-optimization exemption status via `PowerManager.isIgnoringBatteryOptimizations()` and provides intents to request exemption or access the system battery-optimization settings list.
- **Settings UI**: Added a new "System" section with a toggle row for battery optimization. The toggle reflects live system state (not a persisted preference) and launches the appropriate system UI—exemption dialog when enabling, optimization settings list when disabling.
- **ViewModel integration**: 
  - Renamed `adminRefreshTicker` to `systemStateRefreshTicker` to cover both device-admin and battery-exemption state.
  - Renamed `refreshDeviceAdminState()` to `refreshSystemState()` and bumped it on `ON_RESUME` to reflect changes made in system Settings.
  - Added `batteryExemptionRequestIntent()` and `batteryOptimizationSettingsIntent()` methods.
- **Manifest**: Added `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` permission with `BatteryLife` lint suppression (justified because the app ships via F-Droid/GitHub, not Play Store, and the request is only triggered from an opt-in settings row).
- **Strings**: Added English and German localized strings for the battery optimization category and toggle states.

## Implementation Details
- The exemption is optional because stock Android usually keeps a foreground service alive without it.
- The row updates via `refreshSystemState()` once the user returns from the system UI, ensuring the UI reflects the actual OS state.
- Activity result launcher (`batteryLauncher`) is used to detect when the user returns from the exemption dialog or settings, triggering a refresh.

https://claude.ai/code/session_01SqqopAw7r7eu5BrrvHFMau