### PR TITLE
docs(fastlane): add F-Droid changelogs for 1.2.0 (102000)

### DIFF
--- a/fastlane/metadata/android/de-DE/changelogs/102000.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/102000.txt
@@ -1,0 +1,3 @@
+* Neu: Homescreen-Widget – Timer mit einem Tippen starten.
+* Neu: Schnelleinstellungen-Kachel – startet den Timer mit der zuletzt verwendeten Dauer.
+* Neu: Bedienungshilfe als alternative Methode zum Sperren des Bildschirms – ohne Geräteadministrator-Rechte.

--- a/fastlane/metadata/android/en-US/changelogs/102000.txt
+++ b/fastlane/metadata/android/en-US/changelogs/102000.txt
@@ -1,0 +1,3 @@
+* New: home screen widget — start the timer with one tap.
+* New: Quick Settings tile — starts the timer with the last used duration.
+* New: accessibility service as an alternative screen lock method, so the screen can be locked without granting device admin rights.


### PR DESCRIPTION
The `v1.2.0` tag build ([run 32894643357](https://github.com/Xitee1/sleep-timer/actions/runs/32894643357)) failed in the **Verify release metadata matches tag** step:

```
Missing F-Droid changelog: fastlane/metadata/android/en-US/changelogs/102000.txt
```

`app/version.properties` was already bumped correctly in #57 — only the per-release changelogs were missing. This adds them for both locales, worded from the v1.2.0 release notes (widget #50, accessibility screen lock #52, Quick Settings tile #51).

After merge the `v1.2.0` tag has to be moved to the new `main` head and re-pushed so the release build reruns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)